### PR TITLE
Implement complete Leaflet map module

### DIFF
--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -19,7 +19,11 @@ import {
 import {
     updateTempMarker,
     removeTempMarker,
-    initMiniMap // sera maintenant correctement trouvée
+    initMiniMap,
+    geolocateUser,
+    displayAdsOnMap,
+    clearAdsOnMap,
+    getMapInstance
 } from './map.js';
 // import { logout } from './auth.js'; // Importé si handleDeleteAccount est ici
 
@@ -1010,6 +1014,9 @@ function goToAdDetailSlide(index, totalSlides) {
  */
 export async function fetchAllAdsAndRenderOnMap() {
     toggleGlobalLoader(true, "Chargement des annonces...");
+    const loaderEl = document.querySelector('#map-view .map-loader');
+    if (loaderEl) loaderEl.classList.remove('hidden');
+
     try {
         const filters = state.getFilters ? state.getFilters() : {};
         const validFilters = {};
@@ -1046,17 +1053,50 @@ export async function fetchAllAdsAndRenderOnMap() {
         // L'URL d'erreur montre distance=25 et sortBy=createdAt_desc. Si ce sont des défauts, l'API devrait les gérer.
         // Ici, on se concentre sur le fait de ne pas envoyer priceMin=null ou priceMax=null.
 
-        const queryParams = new URLSearchParams(validFilters).toString();
-        const url = queryParams ? `${API_BASE_URL}?${queryParams}` : API_BASE_URL;
-        console.log("Appel de fetchAllAdsAndRenderOnMap avec URL :", url); // Pour débogage
+        // Récupérer les coordonnées depuis la carte ou via la géolocalisation
+        let lat, lng;
+        const map = getMapInstance();
+        if (map && typeof map.getCenter === 'function') {
+            ({ lat, lng } = map.getCenter());
+        } else {
+            const pos = await geolocateUser(false);
+            if (!pos) {
+                if (loaderEl) loaderEl.classList.add('hidden');
+                toggleGlobalLoader(false);
+                showToast("Impossible d'obtenir votre position pour la recherche", 'error');
+                return;
+            }
+            ({ lat, lng } = pos);
+        }
+
+        const queryParams = new URLSearchParams({
+            ...validFilters,
+            lat,
+            lng
+        }).toString();
+        const url = `${API_BASE_URL}?${queryParams}`;
 
         const response = await secureFetch(url, {}, false);
-        // ... (reste de la fonction) ...
+
+        if (loaderEl) loaderEl.classList.add('hidden');
+        toggleGlobalLoader(false);
+
+        const ads = response?.data?.ads || [];
+        state.setAds(ads);
+
+        if (!Array.isArray(ads) || ads.length === 0) {
+            clearAdsOnMap();
+            showToast('Aucune annonce trouvée dans votre rayon.', 'info');
+            return;
+        }
+
+        displayAdsOnMap(ads);
     } catch (error) {
+        if (loaderEl) loaderEl.classList.add('hidden');
         toggleGlobalLoader(false);
         state.setAds([]);
-        document.dispatchEvent(new CustomEvent('mapMarket:renderAdMarkers', { detail: { ads: [] } }));
-        console.error("Erreur lors de la récupération des annonces pour la carte:", error.message, error.response ? await error.response.text() : 'Pas de corps de réponse');
+        clearAdsOnMap();
+        console.error("Erreur lors de la récupération des annonces pour la carte:", error);
         showToast(error.message || "Erreur de chargement des annonces.", "error");
     }
 }


### PR DESCRIPTION
## Summary
- rewrite `public/js/map.js` to implement full Leaflet map handling
- support ads and alerts display, user geolocation, placement mode, and mini-maps
- fix init compatibility and loader usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68416a9b7fdc832e81281b97ae17707b