### PR TITLE
Fix CSS warnings in styles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -93,7 +93,8 @@ body {
     background-color: var(--body-bg);
     color: var(--text-color-base);
     -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    /* The following property is Firefox-specific and not widely supported */
+    /* -moz-osx-font-smoothing: grayscale; */
     display: flex;
     flex-direction: column;
     min-height: 100vh;
@@ -369,8 +370,9 @@ h4 {
 
 .notification-badge {
     position: absolute;
-    top: -var(--spacing-xs);
-    right: -var(--spacing-xs);
+    /* negative offsets require calc for CSS variables */
+    top: calc(-1 * var(--spacing-xs));
+    right: calc(-1 * var(--spacing-xs));
     min-width: 20px;
     height: 20px;
     font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- comment unsupported `-moz-osx-font-smoothing`
- use calc() for negative offsets on notification badge

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68418ed981f8832e828c3f78cb4dc559