### PR TITLE
Improve messaging UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -900,6 +900,10 @@
                     <i class="fa-solid fa-times"></i>
                 </button>
             </div>
+            <nav id="threads-tabs" aria-label="Filtrer les discussions">
+                <button type="button" class="active" data-tab="purchases">Achats</button>
+                <button type="button" data-tab="sales">Ventes</button>
+            </nav>
             <div class="modal-body thread-list-body">
                 <div id="no-threads-placeholder" class="placeholder-message hidden">
                     <i class="fa-solid fa-comment-slash fa-3x"></i>
@@ -938,6 +942,13 @@
                     <button role="menuitem" id="delete-chat-btn" data-i18n="chat.delete">Supprimer</button>
                 </div>
             </div>
+            <div class="chat-ad-summary">
+                <a href="#" id="chat-ad-link">Titre de l'annonce</a> - <span id="chat-ad-price"></span>
+            </div>
+            <div class="chat-security-alert" role="alert">
+                <i class="fa-solid fa-shield-halved"></i>
+                <span>Ne payez jamais en avance et rencontrez le vendeur dans un lieu sûr.</span>
+            </div>
             <div id="chat-messages-container" class="modal-body chat-messages-body" role="log" aria-live="polite">
                 <div id="chat-history-loader" class="loader-container hidden" role="status">
                     <div class="spinner"></div>
@@ -953,6 +964,11 @@
             </div>
             <div id="chat-typing-indicator" class="typing-indicator hidden" aria-live="polite">
                 <span></span><span class="dots"><span>.</span><span>.</span><span>.</span></span>
+            </div>
+            <div id="chat-action-footer" class="chat-actions-toolbar">
+                <button type="button" id="chat-make-offer-btn" class="btn btn-secondary btn-sm"><i class="fa-solid fa-handshake"></i> Faire offre</button>
+                <button type="button" id="chat-share-location-btn" class="btn btn-secondary btn-sm"><i class="fa-solid fa-location-dot"></i> Ma position</button>
+                <button type="button" id="chat-meet-btn" class="btn btn-secondary btn-sm"><i class="fa-solid fa-calendar-check"></i> RDV</button>
             </div>
             <div id="chat-image-preview-container" class="hidden" style="padding: 0 var(--spacing-md); align-self: flex-start;">
                 </div>
@@ -970,6 +986,24 @@
 
     </div>
 </div>
+
+        <div id="contact-seller-modal" class="modal-overlay center-modal" role="dialog" aria-modal="true" aria-labelledby="contact-seller-title" aria-hidden="true" tabindex="-1">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 id="contact-seller-title" class="modal-title"><i class="fa-solid fa-envelope"></i> <span>Contacter le vendeur</span></h2>
+                    <button class="modal-close-btn" data-dismiss-modal="contact-seller-modal" type="button" aria-label="Fermer la prise de contact">
+                        <i class="fa-solid fa-times"></i>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p class="contact-seller-suggest" style="margin-bottom: var(--spacing-sm);">Message suggéré :</p>
+                    <textarea id="contact-seller-message" class="form-control" rows="4">Bonjour, cette annonce est-elle toujours disponible ?</textarea>
+                </div>
+                <div class="modal-footer">
+                    <button id="send-contact-seller-btn" type="button" class="btn btn-primary btn-block"><i class="fa-solid fa-paper-plane"></i> Envoyer</button>
+                </div>
+            </div>
+        </div>
 
             <div id="filters-modal" class="modal-overlay" role="dialog" aria-modal="true"
                 aria-labelledby="filters-modal-title" aria-hidden="true" tabindex="-1">

--- a/public/styles.css
+++ b/public/styles.css
@@ -2816,3 +2816,80 @@ body.dark-mode select.form-control {
 }
 
 /* Ajoutez d'autres catégories selon vos besoins */
+
+/* ---------- Messagerie améliorée ---------- */
+
+/* Modal de prise de contact */
+#contact-seller-modal .modal-content {
+    max-width: 400px;
+}
+
+#contact-seller-modal textarea {
+    width: 100%;
+    resize: vertical;
+    min-height: 80px;
+}
+
+/* Onglets de discussions */
+#threads-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border-color-light);
+}
+
+#threads-tabs button {
+    flex: 1;
+    padding: var(--spacing-sm);
+    background: none;
+    border: none;
+    font-weight: 600;
+    color: var(--gray-600);
+    border-bottom: 2px solid transparent;
+}
+
+#threads-tabs button.active {
+    color: var(--text-color-base);
+    border-color: var(--primary-color);
+}
+
+/* En-tête de conversation collant */
+.chat-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: var(--modal-bg);
+}
+
+.chat-ad-summary {
+    padding: var(--spacing-xs) var(--spacing-md);
+    border-bottom: 1px solid var(--border-color-light);
+    background-color: var(--gray-50);
+    font-size: 0.9rem;
+}
+
+.chat-ad-summary a {
+    font-weight: 600;
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.chat-security-alert {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    background-color: var(--warning-color);
+    color: white;
+    padding: var(--spacing-xs) var(--spacing-md);
+    font-size: 0.85rem;
+}
+
+.chat-actions-toolbar {
+    display: flex;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-top: 1px solid var(--border-color-light);
+    background-color: var(--gray-50);
+}
+
+.chat-actions-toolbar button {
+    flex: 1;
+}


### PR DESCRIPTION
## Summary
- add threads tabs navigation and contact seller modal
- enhance chat view with ad summary, safety alert, and action footer
- add matching styles for new messaging components

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684be7c42ee4832e90a0ba8dd84d700c