### PR TITLE
Add search overlay and map list view

### DIFF
--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -46,6 +46,9 @@ let adDetailDescriptionText, adDetailSellerInfo, adDetailSellerAvatar, adDetailS
 let adDetailActionsContainer, adDetailFavoriteBtn, adDetailContactSellerBtn, adDetailReportBtn;
 let adDetailOwnerActions, adDetailEditAdBtn, adDetailDeleteAdBtn;
 // let adDetailSellerRating, adDetailRatingSection, adAverageRatingDisplay, rateAdBtn, adReviewsList; // Pour les avis futurs
+let imageViewerModal, viewerImage, viewerPrevBtn, viewerNextBtn;
+let viewerImages = [];
+let viewerIndex = 0;
 
 // --- Éléments du DOM pour la modale "Mes Annonces" ---
 let myAdsModal, myAdsListContainer, myAdItemTemplate, noMyAdsPlaceholder, myAdsLoader;
@@ -108,6 +111,14 @@ function initAdsUI() {
     // adAverageRatingDisplay = document.getElementById('ad-average-rating-display'); // Pour les avis futurs
     // rateAdBtn = document.getElementById('rate-ad-btn'); // Pour les avis futurs
     // adReviewsList = document.getElementById('ad-reviews-list'); // Pour les avis futurs
+
+    imageViewerModal = document.getElementById('image-viewer-modal');
+    viewerImage = document.getElementById('viewer-image');
+    viewerPrevBtn = document.getElementById('viewer-prev');
+    viewerNextBtn = document.getElementById('viewer-next');
+
+    viewerPrevBtn?.addEventListener('click', () => showViewerImage(viewerIndex - 1));
+    viewerNextBtn?.addEventListener('click', () => showViewerImage(viewerIndex + 1));
 
     // Modale "Mes Annonces"
     myAdsModal = document.getElementById('my-ads-modal');
@@ -1002,6 +1013,8 @@ function setupAdDetailCarousel(imageUrls) {
         ? imageUrls
         : ['https://placehold.co/600x400/e0e0e0/757575?text=Aucune+image'];
 
+    viewerImages = images;
+
     const isPlaceholder = imageUrls.length === 0;
 
     // Création des slides
@@ -1021,6 +1034,7 @@ function setupAdDetailCarousel(imageUrls) {
             img.src = 'https://placehold.co/600x400/e0e0e0/757575?text=Image+indisponible';
             img.alt = 'Image indisponible';
         };
+        img.addEventListener('click', () => openImageViewer(index));
 
         slide.appendChild(img);
         adDetailCarouselTrack.appendChild(slide);
@@ -1095,6 +1109,22 @@ function goToAdDetailSlide(index, totalSlides) {
         adDetailCarouselTrack.style.transform = `translateX(-${currentAdDetailCarouselSlide * 100}%)`;
     }
     updateAdDetailCarouselUI(totalSlides);
+}
+
+function openImageViewer(startIndex) {
+    if (!imageViewerModal || !viewerImage) return;
+    viewerIndex = startIndex;
+    showViewerImage(viewerIndex);
+    document.dispatchEvent(new CustomEvent('mapmarket:openModal', { detail: { modalId: 'image-viewer-modal' } }));
+}
+
+function showViewerImage(index) {
+    if (!viewerImages.length) return;
+    viewerIndex = (index + viewerImages.length) % viewerImages.length;
+    if (viewerImage) {
+        viewerImage.src = viewerImages[viewerIndex];
+        viewerImage.alt = `Image ${viewerIndex + 1}`;
+    }
 }
 
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -11,6 +11,7 @@ import * as State from './state.js';
 import * as Auth from './auth.js';
 import * as Modals from './modals.js';
 import * as MapCtrl from './map.js';
+import * as Search from './search.js';
 import * as Ads from './ads.js';
 import * as Favorites from './favorites.js';
 import * as Profile from './profile.js';
@@ -43,6 +44,7 @@ class App {
             MapCtrl.init();
             Ads.init();
             Filters.init();
+            Search.init();
             Alerts.init();
             Favorites.init();
             Profile.init();
@@ -76,47 +78,6 @@ class App {
     }
 
     setupGlobalEventListeners() {
-        // --- Barre de recherche rétractable ---
-        const headerShowSearchBtn = document.getElementById('header-show-search-btn');
-        const searchBarWrapper = document.getElementById('header-search-bar-wrapper');
-        const closeSearchBarBtn = document.getElementById('close-search-bar-btn');
-        const mainSearchInput = document.getElementById('main-search-input');
-
-        if (headerShowSearchBtn && searchBarWrapper && closeSearchBarBtn && mainSearchInput) {
-            headerShowSearchBtn.addEventListener('click', () => {
-                const isCurrentlyHidden = searchBarWrapper.classList.contains('hidden');
-                if (isCurrentlyHidden) {
-                    searchBarWrapper.classList.remove('hidden');
-                    // Forcer un reflow pour que la transition s'applique correctement après le display:block
-                    void searchBarWrapper.offsetWidth;
-                    searchBarWrapper.setAttribute('aria-hidden', 'false');
-                    headerShowSearchBtn.setAttribute('aria-expanded', 'true');
-                    mainSearchInput.focus();
-                } else {
-                    searchBarWrapper.classList.add('hidden');
-                    searchBarWrapper.setAttribute('aria-hidden', 'true');
-                    headerShowSearchBtn.setAttribute('aria-expanded', 'false');
-                }
-            });
-
-            closeSearchBarBtn.addEventListener('click', () => {
-                searchBarWrapper.classList.add('hidden');
-                searchBarWrapper.setAttribute('aria-hidden', 'true');
-                headerShowSearchBtn.setAttribute('aria-expanded', 'false');
-                headerShowSearchBtn.focus();
-            });
-
-            // Fermer la barre de recherche avec la touche Echap
-            document.addEventListener('keydown', (event) => {
-                if (event.key === 'Escape' && !searchBarWrapper.classList.contains('hidden')) {
-                    closeSearchBarBtn.click();
-                }
-            });
-        } else {
-            console.warn("Éléments pour la barre de recherche rétractable non trouvés. La fonctionnalité pourrait être inactive.");
-        }
-
-
         // --- Boutons de l'en-tête (Profil, Filtres, Notifications) ---
         const headerProfileBtn = document.getElementById('header-profile-btn');
         if (headerProfileBtn) {

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -20,6 +20,7 @@ let profileForm, profileNameField, profileEmailField, profileNewPasswordField, p
 let editProfileBtn, saveProfileBtn, cancelEditProfileBtn, profileEditActions;
 let deleteAccountTriggerBtn, deleteAccountConfirmSection, deleteAccountCheckbox, confirmDeleteAccountBtn, cancelDeleteAccountBtn;
 let statsAdsPublished, statsAvgRating, statsFavoritesCount;
+let profileAchievementsSection;
 
 // Champs éditables
 let editableFields = [];
@@ -67,6 +68,7 @@ function initProfileUI() {
     statsAdsPublished = document.getElementById('stats-ads-published');
     statsAvgRating = document.getElementById('stats-avg-rating');
     statsFavoritesCount = document.getElementById('stats-favorites-count');
+    profileAchievementsSection = document.getElementById('profile-achievements-section');
 
     // --- Écouteurs d'événements ---
     document.addEventListener('mapMarket:modalOpened', (event) => {
@@ -201,8 +203,38 @@ function populateProfileFields(userData) {
     if (statsAvgRating) statsAvgRating.textContent = userData.stats?.avgRating ? `${parseFloat(userData.stats.avgRating).toFixed(1)}/5` : 'N/A';
     if (statsFavoritesCount) statsFavoritesCount.textContent = userData.stats?.favoritesCount ?? '0';
 
+    // Mise à jour des barres de progression
+    if (statsAdsPublished) {
+        const pct = Math.min(100, (parseInt(userData.stats?.adsPublished || 0) / 10) * 100);
+        statsAdsPublished.nextElementSibling?.querySelector('.fill')?.style.setProperty('width', pct + '%');
+    }
+    if (statsAvgRating) {
+        const pct = Math.min(100, ((parseFloat(userData.stats?.avgRating) || 0) / 5) * 100);
+        statsAvgRating.nextElementSibling?.querySelector('.fill')?.style.setProperty('width', pct + '%');
+    }
+    if (statsFavoritesCount) {
+        const pct = Math.min(100, (parseInt(userData.stats?.favoritesCount || 0) / 10) * 100);
+        statsFavoritesCount.nextElementSibling?.querySelector('.fill')?.style.setProperty('width', pct + '%');
+    }
+
+    updateAchievements(userData);
+
     if (profileNewPasswordField) profileNewPasswordField.value = '';
     if (profileConfirmPasswordField) profileConfirmPasswordField.value = '';
+}
+
+function updateAchievements(userData) {
+    if (!profileAchievementsSection) return;
+    const badges = profileAchievementsSection.querySelectorAll('.achievement-badge');
+    const achievements = {
+        firstAd: (userData.stats?.adsPublished || 0) > 0,
+        fastSeller: userData.stats?.fastSales, // à définir selon la logique réelle
+        collector: Array.isArray(userData.favorites) && userData.favorites.length >= 10
+    };
+
+    if (badges[0] && achievements.firstAd) badges[0].classList.remove('locked');
+    if (badges[1] && achievements.fastSeller) badges[1].classList.remove('locked');
+    if (badges[3] && achievements.collector) badges[3].classList.remove('locked');
 }
 
 

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,0 +1,128 @@
+// js/search.js
+
+import * as state from './state.js';
+
+const RECENT_KEY = 'mapMarketRecentSearches';
+
+export function init() {
+    const headerShowSearchBtn = document.getElementById('header-show-search-btn');
+    const searchBarWrapper = document.getElementById('header-search-bar-wrapper');
+    const closeSearchBarBtn = document.getElementById('close-search-bar-btn');
+    const mainSearchInput = document.getElementById('main-search-input');
+    const mainSearchButton = document.getElementById('main-search-button');
+
+    if (!headerShowSearchBtn || !searchBarWrapper || !closeSearchBarBtn || !mainSearchInput) {
+        console.warn('Search overlay: éléments manquants.');
+        return;
+    }
+
+    headerShowSearchBtn.addEventListener('click', openOverlay);
+    closeSearchBarBtn.addEventListener('click', closeOverlay);
+    mainSearchButton?.addEventListener('click', executeSearch);
+
+    mainSearchInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            executeSearch();
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && searchBarWrapper.classList.contains('search-overlay--active')) {
+            closeOverlay();
+        }
+    });
+
+    renderRecentSearches();
+    renderTrendingCategories();
+
+    function openOverlay() {
+        searchBarWrapper.classList.add('search-overlay--active');
+        searchBarWrapper.classList.remove('hidden');
+        searchBarWrapper.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('search-overlay--active');
+        headerShowSearchBtn.setAttribute('aria-expanded', 'true');
+        renderRecentSearches();
+        renderTrendingCategories();
+        mainSearchInput.focus();
+    }
+
+    function closeOverlay() {
+        searchBarWrapper.classList.remove('search-overlay--active');
+        searchBarWrapper.classList.add('hidden');
+        searchBarWrapper.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('search-overlay--active');
+        headerShowSearchBtn.setAttribute('aria-expanded', 'false');
+        headerShowSearchBtn.focus();
+    }
+
+    function executeSearch() {
+        const term = mainSearchInput.value.trim();
+        if (!term) return;
+        saveSearchTerm(term);
+        const current = state.get('filters');
+        state.set('filters', { ...current, keywords: term });
+        document.dispatchEvent(new CustomEvent('mapMarket:filtersApplied', { detail: state.get('filters') }));
+        closeOverlay();
+    }
+}
+
+export function saveSearchTerm(term) {
+    if (!term) return;
+    const items = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+    const trimmed = term.trim();
+    const existingIdx = items.indexOf(trimmed);
+    if (existingIdx !== -1) items.splice(existingIdx, 1);
+    items.unshift(trimmed);
+    localStorage.setItem(RECENT_KEY, JSON.stringify(items.slice(0, 4)));
+}
+
+export function renderRecentSearches() {
+    const container = document.getElementById('recent-searches');
+    if (!container) return;
+    container.innerHTML = '';
+    const searches = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+    if (!searches.length) {
+        container.classList.add('hidden');
+        return;
+    }
+    container.classList.remove('hidden');
+    const fragment = document.createDocumentFragment();
+    searches.forEach(term => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'recent-search-item';
+        btn.textContent = term;
+        btn.addEventListener('click', () => {
+            const input = document.getElementById('main-search-input');
+            if (input) input.value = term;
+            document.getElementById('main-search-button')?.click();
+        });
+        fragment.appendChild(btn);
+    });
+    container.appendChild(fragment);
+}
+
+export function renderTrendingCategories() {
+    const container = document.getElementById('trending-categories');
+    if (!container) return;
+    container.innerHTML = '';
+    const categories = state.getCategories();
+    const fragment = document.createDocumentFragment();
+    categories.forEach(cat => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'trend-chip';
+        btn.textContent = cat.name;
+        btn.dataset.categoryId = cat.id;
+        btn.addEventListener('click', () => {
+            const filters = state.get('filters');
+            state.set('filters', { ...filters, category: cat.id });
+            document.dispatchEvent(new CustomEvent('mapMarket:filtersApplied', { detail: state.get('filters') }));
+            const closeBtn = document.getElementById('close-search-bar-btn');
+            closeBtn?.click();
+        });
+        fragment.appendChild(btn);
+    });
+    container.appendChild(fragment);
+}


### PR DESCRIPTION
## Summary
- implement immersive search overlay with recent searches and trending categories
- toggle between map and list views with animated markers
- add image viewer modal for ad detail images
- show progress bars and achievements on profile

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bf5524fbc832e92a955680b191cd2