### PR TITLE
Implement seller info UI and messaging features

### DIFF
--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -43,6 +43,7 @@ let adDetailModal, adDetailBodyContent, adDetailLoader, adDetailContent;
 let adDetailCarouselTrack, adDetailCarouselPrevBtn, adDetailCarouselNextBtn, adDetailCarouselDotsContainer;
 let adDetailItemTitle, adDetailPrice, adDetailCategory, adDetailLocation, adDetailDate;
 let adDetailDescriptionText, adDetailSellerInfo, adDetailSellerAvatar, adDetailSellerName;
+let adDetailSellerSince, adDetailSellerAdsCount, adDetailViewProfileBtn;
 let adDetailActionsContainer, adDetailFavoriteBtn, adDetailContactSellerBtn, adDetailReportBtn;
 let adDetailOwnerActions, adDetailEditAdBtn, adDetailDeleteAdBtn;
 // let adDetailSellerRating, adDetailRatingSection, adAverageRatingDisplay, rateAdBtn, adReviewsList; // Pour les avis futurs
@@ -99,6 +100,9 @@ function initAdsUI() {
     adDetailSellerInfo = document.getElementById('ad-detail-seller-info');
     adDetailSellerAvatar = document.getElementById('ad-detail-seller-avatar');
     adDetailSellerName = document.getElementById('ad-detail-seller-name');
+    adDetailSellerSince = document.getElementById('ad-detail-seller-since');
+    adDetailSellerAdsCount = document.getElementById('ad-detail-seller-ads-count');
+    adDetailViewProfileBtn = document.getElementById('ad-detail-view-profile-btn');
     // adDetailSellerRating = document.getElementById('ad-detail-seller-rating'); // Pour les avis futurs
     adDetailActionsContainer = document.getElementById('ad-detail-actions-container');
     adDetailFavoriteBtn = document.getElementById('ad-detail-favorite-btn');
@@ -898,6 +902,16 @@ async function loadAndDisplayAdDetails(adId) {
                 }
                 if (adDetailSellerName) adDetailSellerName.textContent = sanitizeHTML(ad.userId.name);
                 if (adDetailSellerInfo) adDetailSellerInfo.dataset.sellerId = ad.userId._id;
+                if (adDetailSellerSince) adDetailSellerSince.textContent = `Membre depuis ${formatDate(ad.userId.createdAt)}`;
+                if (adDetailSellerAdsCount) adDetailSellerAdsCount.textContent = `${ad.userId.stats?.adsPublished || 0} annonce(s) active(s)`;
+                if (adDetailViewProfileBtn) {
+                    const newBtn = adDetailViewProfileBtn.cloneNode(true);
+                    adDetailViewProfileBtn.replaceWith(newBtn);
+                    adDetailViewProfileBtn = newBtn;
+                    adDetailViewProfileBtn.addEventListener('click', () => {
+                        document.dispatchEvent(new CustomEvent('mapMarket:viewPublicProfile', { detail: { userId: ad.userId._id } }));
+                    });
+                }
             } else {
                 if (adDetailSellerInfo) adDetailSellerInfo.classList.add('hidden');
             }


### PR DESCRIPTION
## Summary
- enhance ad detail seller section with join date, ads count and profile button
- add messaging actions for offers, locations and meetings
- support tabs for threads filtering and pass role to API
- allow message renderer to display interactive cards and handle responses

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bfce38020832eaf9c7661c9c7b0c5