### PR TITLE
Fix messaging modals and Font Awesome loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,9 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>MapMarket - Marketplace Géolocalisée</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
-        integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
-        crossorigin="anonymous" referrerpolicy="no-referrer">
+    <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -1036,6 +1034,50 @@
     </div>
 </div>
 
+        <div id="offer-modal" class="modal-overlay center-modal" role="dialog" aria-modal="true" aria-hidden="true" tabindex="-1">
+            <div class="modal-content" style="max-width: 320px;">
+                <div class="modal-header">
+                    <h2 class="modal-title">Faire une offre</h2>
+                    <button class="modal-close-btn" data-dismiss-modal="offer-modal" type="button" aria-label="Fermer">×</button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="offer-amount-input">Votre offre (€)</label>
+                        <input type="number" id="offer-amount-input" class="form-control" placeholder="Ex: 50" min="0">
+                        <small id="offer-amount-error" class="form-error-message"></small>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button id="submit-offer-btn" class="btn btn-primary">Soumettre l'offre</button>
+                </div>
+            </div>
+        </div>
+        
+        <div id="appointment-modal" class="modal-overlay center-modal" role="dialog" aria-modal="true" aria-hidden="true" tabindex="-1">
+            <div class="modal-content" style="max-width: 400px;">
+                <div class="modal-header">
+                    <h2 class="modal-title">Planifier un rendez-vous</h2>
+                    <button class="modal-close-btn" data-dismiss-modal="appointment-modal" type="button" aria-label="Fermer">×</button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="appointment-date-input">Date du RDV</label>
+                        <input type="date" id="appointment-date-input" class="form-control">
+                    </div>
+                    <div class="form-group">
+                        <label for="appointment-time-input">Heure du RDV</label>
+                        <input type="time" id="appointment-time-input" class="form-control">
+                    </div>
+                    <div class="form-group">
+                        <label for="appointment-location-input">Lieu du RDV (optionnel)</label>
+                        <input type="text" id="appointment-location-input" class="form-control" placeholder="Ex: Devant la mairie">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button id="submit-appointment-btn" class="btn btn-primary">Proposer ce RDV</button>
+                </div>
+            </div>
+        </div>
         <div id="contact-seller-modal" class="modal-overlay center-modal" role="dialog" aria-modal="true" aria-labelledby="contact-seller-title" aria-hidden="true" tabindex="-1">
             <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
## Summary
- load Font Awesome using kit script to avoid 404 errors
- add missing offer and appointment modals needed by messages.js

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c020cad7c832eb6a6f8c446ffdf23