### PR TITLE
Fix image routes and message validation

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -224,7 +224,8 @@ exports.sendMessage = asyncHandler(async (req, res, next) => {
         return next(new AppError('recipientId et adId sont requis pour démarrer une nouvelle discussion.', 400));
     }
 
-    if (!text && !req.file) {
+    // Vérifie qu'il y a du texte non vide ou une image à envoyer
+    if ((!text || text.trim() === '') && !req.file) {
         return next(new AppError('Un message doit contenir du texte ou une image.', 400));
     }
 

--- a/middlewares/validationMiddleware.js
+++ b/middlewares/validationMiddleware.js
@@ -170,11 +170,9 @@ const createMessageSchema = Joi.object({
         then: Joi.optional(),
         otherwise: Joi.required()
     }),
-    text: Joi.string().trim().max(2000).when('image', {
-        is: Joi.exist(),
-        then: Joi.optional().allow(''),
-        otherwise: Joi.required()
-    }),
+    // Le texte est optionnel et peut être une chaîne vide ;
+    // la présence d'au moins un contenu (texte ou image) sera vérifiée dans le contrôleur
+    text: Joi.string().trim().max(2000).allow('').optional()
 }).xor('threadId', 'recipientId');
 
 // Schémas pour les alertes

--- a/server.js
+++ b/server.js
@@ -171,18 +171,12 @@ app.use('/api/settings', settingRoutes);
 app.get('/favicon.ico', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'favicon.ico'));
 });
-app.use('/avatars', express.static(path.join(__dirname, '/uploads/avatars')));
 // Catch-all SPA (doit être après toutes les routes API et fichiers statiques)
-
-
-// Sert le dossier 'uploads' (qui contient 'avatars') sous la route '/uploads'
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 app.get('*', (req, res, next) => {
   if (
     req.originalUrl.startsWith('/api') ||
     req.originalUrl.startsWith('/uploads') ||
     req.originalUrl.startsWith('/favicon.ico') ||
-    req.originalUrl.startsWith('/avatars') ||
     req.originalUrl.match(/\.(js|css|png|jpg|jpeg|svg|ico|json|webmanifest|webp|mp3|mp4)$/)
   ) {
     return next();


### PR DESCRIPTION
## Summary
- serve uploads directory once and remove `/avatars` static route
- loosen Joi validation on message text
- ensure messages contain text or image in controller

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c23720680832eb53e318b7cd0745a