### PR TITLE
Fix message validation crash

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -264,9 +264,8 @@ exports.sendMessage = asyncHandler(async (req, res, next) => {
    const messageData = {
         threadId: currentThreadId,
         senderId,
-        // S'assure que 'text' est toujours une chaîne. Si 'text' est falsy (null, undefined, ""),
-        // il deviendra une chaîne vide, ce qui est valide pour le schéma Mongoose.
-        text: text || '', 
+        // Cast du contenu en chaîne pour éviter les erreurs de type côté base de données
+        text: typeof text === 'string' ? text : String(text || ''),
     };
     if (req.file) {
         messageData.imageUrl = path.join('messages', req.file.filename).replace(/\\/g, '/');


### PR DESCRIPTION
## Summary
- handle Joi validation errors consistently
- coerce message text to a string before saving

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c3aaa233c832ea8d7316a134e9787