### PR TITLE
Update seller stats in ad details

### DIFF
--- a/controllers/adController.js
+++ b/controllers/adController.js
@@ -262,10 +262,22 @@ exports.getAdById = asyncHandler(async (req, res, next) => {
     ad.viewCount = (ad.viewCount || 0) + 1;
     await ad.save({ validateBeforeSave: false });
 
+    let adToReturn = mapImageUrls(req, ad.toObject());
+
+    if (ad && ad.userId) {
+        const adsPublishedCount = await Ad.countDocuments({ userId: ad.userId._id, status: 'online' });
+        const adObject = ad.toObject();
+        if (!adObject.userId.stats) {
+            adObject.userId.stats = {};
+        }
+        adObject.userId.stats.adsPublished = adsPublishedCount;
+        adToReturn = mapImageUrls(req, adObject);
+    }
+
     res.status(200).json({
         success: true,
         data: {
-            ad: mapImageUrls(req, ad.toObject()),
+            ad: adToReturn,
         },
     });
 });

--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -896,7 +896,7 @@ async function loadAndDisplayAdDetails(adId) {
                 }
                 if (adDetailSellerName) adDetailSellerName.textContent = sanitizeHTML(ad.userId.name);
                 if (adDetailSellerInfo) adDetailSellerInfo.dataset.sellerId = ad.userId._id;
-                if (adDetailSellerSince) adDetailSellerSince.textContent = `Membre depuis ${formatDate(ad.userId.createdAt)}`;
+                if (adDetailSellerSince) adDetailSellerSince.textContent = `Membre depuis ${formatDate(ad.userId.createdAt, { month: 'long', year: 'numeric' })}`;
                 if (adDetailSellerAdsCount) adDetailSellerAdsCount.textContent = `${ad.userId.stats?.adsPublished || 0} annonce(s) active(s)`;
                 if (adDetailViewProfileBtn) {
                     const newBtn = adDetailViewProfileBtn.cloneNode(true);


### PR DESCRIPTION
## Summary
- compute seller's active ads count in `getAdById`
- format seller join date as Month Year in ad detail modal

## Testing
- `npm run test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c6e1c4db8832eb7d11228cb59fad8