### PR TITLE
Fix user stats and remove profile button

### DIFF
--- a/controllers/adController.js
+++ b/controllers/adController.js
@@ -262,22 +262,25 @@ exports.getAdById = asyncHandler(async (req, res, next) => {
     ad.viewCount = (ad.viewCount || 0) + 1;
     await ad.save({ validateBeforeSave: false });
 
-    let adToReturn = mapImageUrls(req, ad.toObject());
-
     if (ad && ad.userId) {
         const adsPublishedCount = await Ad.countDocuments({ userId: ad.userId._id, status: 'online' });
+        // Crée une copie modifiable de l'objet ad
         const adObject = ad.toObject();
+
+        // S'assurer que le sous-objet stats existe
         if (!adObject.userId.stats) {
             adObject.userId.stats = {};
         }
         adObject.userId.stats.adsPublished = adsPublishedCount;
-        adToReturn = mapImageUrls(req, adObject);
+
+        // Mettre à jour la variable `ad` utilisée par le reste de la fonction
+        Object.assign(ad, adObject);
     }
 
     res.status(200).json({
         success: true,
         data: {
-            ad: adToReturn,
+            ad: mapImageUrls(req, ad.toObject()),
         },
     });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -699,9 +699,6 @@
                                             aria-label="Note moyenne du vendeur"></div>
                                         <p id="ad-detail-seller-since" class="seller-extra"></p>
                                         <p id="ad-detail-seller-ads-count" class="seller-extra"></p>
-                                        <button id="ad-detail-view-profile-btn" type="button" class="btn btn-sm btn-secondary">
-                                            Voir le profil
-                                        </button>
                                     </div>
                                 </div>
                             </section>

--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -43,7 +43,7 @@ let adDetailModal, adDetailBodyContent, adDetailLoader, adDetailContent;
 let adDetailCarouselTrack, adDetailCarouselPrevBtn, adDetailCarouselNextBtn, adDetailCarouselDotsContainer;
 let adDetailItemTitle, adDetailPrice, adDetailCategory, adDetailLocation, adDetailDate;
 let adDetailDescriptionText, adDetailSellerInfo, adDetailSellerAvatar, adDetailSellerName;
-let adDetailSellerSince, adDetailSellerAdsCount, adDetailViewProfileBtn;
+let adDetailSellerSince, adDetailSellerAdsCount;
 let adDetailActionsContainer, adDetailFavoriteBtn, adDetailContactSellerBtn, adDetailReportBtn;
 let adDetailOwnerActions, adDetailEditAdBtn, adDetailDeleteAdBtn;
 let imageViewerModal, viewerImage, viewerPrevBtn, viewerNextBtn;
@@ -101,7 +101,6 @@ function initAdsUI() {
     adDetailSellerName = document.getElementById('ad-detail-seller-name');
     adDetailSellerSince = document.getElementById('ad-detail-seller-since');
     adDetailSellerAdsCount = document.getElementById('ad-detail-seller-ads-count');
-    adDetailViewProfileBtn = document.getElementById('ad-detail-view-profile-btn');
     // adDetailSellerRating = document.getElementById('ad-detail-seller-rating'); // Pour les avis futurs
     adDetailActionsContainer = document.getElementById('ad-detail-actions-container');
     adDetailFavoriteBtn = document.getElementById('ad-detail-favorite-btn');
@@ -898,14 +897,6 @@ async function loadAndDisplayAdDetails(adId) {
                 if (adDetailSellerInfo) adDetailSellerInfo.dataset.sellerId = ad.userId._id;
                 if (adDetailSellerSince) adDetailSellerSince.textContent = `Membre depuis ${formatDate(ad.userId.createdAt, { month: 'long', year: 'numeric' })}`;
                 if (adDetailSellerAdsCount) adDetailSellerAdsCount.textContent = `${ad.userId.stats?.adsPublished || 0} annonce(s) active(s)`;
-                if (adDetailViewProfileBtn) {
-                    const newBtn = adDetailViewProfileBtn.cloneNode(true);
-                    adDetailViewProfileBtn.replaceWith(newBtn);
-                    adDetailViewProfileBtn = newBtn;
-                    adDetailViewProfileBtn.addEventListener('click', () => {
-                        document.dispatchEvent(new CustomEvent('mapMarket:viewPublicProfile', { detail: { userId: ad.userId._id } }));
-                    });
-                }
             } else {
                 if (adDetailSellerInfo) adDetailSellerInfo.classList.add('hidden');
             }


### PR DESCRIPTION
## Summary
- ensure ad stats are attached before sending response
- remove profile button from ad detail modal
- clean up JS handling for removed button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c7478c9c0832e92f4ba38acd000f2