### PR TITLE
Fix image viewer overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -732,7 +732,7 @@
 
             <div id="image-viewer-modal" class="modal-overlay" aria-modal="true" aria-hidden="true" tabindex="-1">
                 <div class="modal-content">
-                    <button class="modal-close-btn" data-dismiss-modal="image-viewer-modal" type="button" aria-label="Fermer la vue d'image" style="align-self:flex-end;">
+                    <button class="modal-close-btn" id="close-image-viewer-btn" type="button" aria-label="Fermer la vue d'image" style="align-self:flex-end;">
                         <i class="fa-solid fa-times"></i>
                     </button>
                     <div id="image-viewer-container" class="image-viewer">

--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -46,7 +46,7 @@ let adDetailDescriptionText, adDetailSellerInfo, adDetailSellerAvatar, adDetailS
 let adDetailSellerSince, adDetailSellerAdsCount;
 let adDetailActionsContainer, adDetailFavoriteBtn, adDetailContactSellerBtn, adDetailReportBtn;
 let adDetailOwnerActions, adDetailEditAdBtn, adDetailDeleteAdBtn;
-let imageViewerModal, viewerImage, viewerPrevBtn, viewerNextBtn;
+let imageViewerModal, viewerImage, viewerPrevBtn, viewerNextBtn, closeImageViewerBtn;
 let viewerImages = [];
 let viewerIndex = 0;
 
@@ -114,9 +114,13 @@ function initAdsUI() {
     viewerImage = document.getElementById('viewer-image');
     viewerPrevBtn = document.getElementById('viewer-prev');
     viewerNextBtn = document.getElementById('viewer-next');
+    closeImageViewerBtn = document.getElementById('close-image-viewer-btn');
 
     viewerPrevBtn?.addEventListener('click', () => showViewerImage(viewerIndex - 1));
     viewerNextBtn?.addEventListener('click', () => showViewerImage(viewerIndex + 1));
+    closeImageViewerBtn?.addEventListener('click', closeImageViewer);
+
+    document.addEventListener('keydown', handleImageViewerKeydown, true);
 
     // Modale "Mes Annonces"
     myAdsModal = document.getElementById('my-ads-modal');
@@ -1127,7 +1131,22 @@ function openImageViewer(startIndex) {
     if (!imageViewerModal || !viewerImage) return;
     viewerIndex = startIndex;
     showViewerImage(viewerIndex);
-    document.dispatchEvent(new CustomEvent('mapmarket:openModal', { detail: { modalId: 'image-viewer-modal' } }));
+    imageViewerModal.classList.remove('hidden');
+    imageViewerModal.setAttribute('aria-hidden', 'false');
+}
+
+function closeImageViewer() {
+    if (!imageViewerModal) return;
+    imageViewerModal.classList.add('hidden');
+    imageViewerModal.setAttribute('aria-hidden', 'true');
+}
+
+function handleImageViewerKeydown(event) {
+    if (event.key === 'Escape' && imageViewerModal && imageViewerModal.getAttribute('aria-hidden') === 'false') {
+        event.stopPropagation();
+        event.preventDefault();
+        closeImageViewer();
+    }
 }
 
 function showViewerImage(index) {


### PR DESCRIPTION
## Summary
- keep ad detail modal open when image viewer opens by managing viewer DOM directly
- add Close button ID and ESC handler for viewer overlay
- update HTML for viewer close button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c893377f0832eb80e7f21a8dfbbaf