### PR TITLE
Improve chat message types

### DIFF
--- a/models/messageModel.js
+++ b/models/messageModel.js
@@ -20,13 +20,20 @@ const messageSchema = new mongoose.Schema({
     //     ref: 'User',
     //     required: true,
     // },
+    type: {
+        type: String,
+        enum: ['text', 'image', 'offer', 'appointment', 'location', 'system'],
+        default: 'text'
+    },
+    metadata: {
+        type: mongoose.Schema.Types.Mixed
+    },
     text: {
         type: String,
         trim: true,
-        // Requis seulement si imageUrl n'est pas fourni
         validate: {
             validator: function(v) {
-                // Le message doit avoir soit du texte, soit une image
+                if (this.type && this.type !== 'text') return true;
                 return v || this.imageUrl;
             },
             message: 'Un message doit contenir du texte ou une image.'

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -41,6 +41,11 @@ const userSchema = new mongoose.Schema({
         type: String,
         default: 'avatar-default.svg', // Ou une URL placeholder complète
     },
+    isOnline: {
+        type: Boolean,
+        default: false
+    },
+    lastSeen: Date,
     role: {
         type: String,
         enum: ['user', 'admin', 'moderator'], // Définir les rôles possibles

--- a/public/index.html
+++ b/public/index.html
@@ -1074,6 +1074,9 @@
                                     <a href="#" target="_blank" class="location-map-link btn btn-sm btn-secondary">Ouvrir dans Plans</a>
                                 </div>
                             </template>
+                            <template id="system-message-template">
+                                <div class="system-message-text"></div>
+                            </template>
                         </div>
                         <div id="chat-typing-indicator" class="typing-indicator hidden" aria-live="polite">
                             <span></span><span class="dots"><span>.</span><span>.</span><span>.</span></span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1914,14 +1914,8 @@ h4 {
     border-left: 0;
 }
 
-.chat-message[data-sender-id="me"] + .chat-message[data-sender-id="me"] {
+.chat-message.is-consecutive {
     margin-top: 2px;
-    border-top-right-radius: var(--border-radius-xs);
-}
-
-.chat-message:not([data-sender-id="me"])+.chat-message:not([data-sender-id="me"]) {
-    margin-top: 2px;
-    border-top-left-radius: var(--border-radius-xs);
 }
 
 .message-time {
@@ -1949,6 +1943,13 @@ h4 {
     margin-right: auto;
     text-align: center;
     box-shadow: none;
+}
+
+.date-separator {
+    text-align: center;
+    margin: var(--spacing-sm) 0;
+    color: var(--gray-500);
+    font-size: 0.85rem;
 }
 
 .chat-input-footer {

--- a/routes/messageRoutes.js
+++ b/routes/messageRoutes.js
@@ -26,6 +26,8 @@ router.post(
     validateSendMessageWithImage,            // 2. Joi valide le corps (threadId/recipientId/texte optionnel)
     messageController.sendMessage            // 3. Le contrôleur traite la requête
 );
+router.post('/messages/:messageId/offer/accept', messageController.acceptOffer);
+router.post('/messages/:messageId/offer/decline', messageController.declineOffer);
 
 
 // Route pour signaler un message


### PR DESCRIPTION
## Summary
- add type and metadata fields to messages
- support rich message types in controller and routes
- update user model with online status
- handle offer acceptance/decline
- templates for interactive cards and system messages
- render typed messages and add date separators
- add presence updates via socket
- styles for consecutive messages and separators

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d79bed1f0832e9533cc500ca83cfb