### PR TITLE
Refactor messaging front-end

### DIFF
--- a/models/messageModel.js
+++ b/models/messageModel.js
@@ -26,7 +26,21 @@ const messageSchema = new mongoose.Schema({
         default: 'text'
     },
     metadata: {
-        type: mongoose.Schema.Types.Mixed
+        type: mongoose.Schema.Types.Mixed,
+        validate: {
+            validator: function(v) {
+                if (this.type === 'offer') {
+                    return v && typeof v.amount === 'number' && v.currency &&
+                        ['pending','accepted','declined'].includes(v.status);
+                }
+                if (this.type === 'appointment') {
+                    return v && v.date && v.location !== undefined &&
+                        ['pending','confirmed','cancelled','canceled'].includes(v.status);
+                }
+                return true;
+            },
+            message: 'Métadonnées invalides pour ce type de message.'
+        }
     },
     text: {
         type: String,

--- a/public/styles.css
+++ b/public/styles.css
@@ -1914,8 +1914,54 @@ h4 {
     border-left: 0;
 }
 
-.chat-message.is-consecutive {
+
+.chat-message.is-first-in-group {
+    margin-top: var(--spacing-sm);
+}
+
+.chat-message.is-middle-in-group,
+.chat-message.is-last-in-group {
     margin-top: 2px;
+}
+
+.chat-message[data-sender-id="me"].is-first-in-group {
+    border-top-right-radius: var(--border-radius-lg);
+    border-bottom-right-radius: var(--border-radius-xs);
+}
+
+.chat-message[data-sender-id="me"].is-middle-in-group {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.chat-message[data-sender-id="me"].is-last-in-group {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: var(--border-radius-lg);
+}
+
+.chat-message[data-sender-id="me"].is-single-message {
+    border-top-right-radius: var(--border-radius-lg);
+    border-bottom-right-radius: var(--border-radius-lg);
+}
+
+.chat-message:not([data-sender-id="me"]).is-first-in-group {
+    border-top-left-radius: var(--border-radius-lg);
+    border-bottom-left-radius: var(--border-radius-xs);
+}
+
+.chat-message:not([data-sender-id="me"]).is-middle-in-group {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.chat-message:not([data-sender-id="me"]).is-last-in-group {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: var(--border-radius-lg);
+}
+
+.chat-message:not([data-sender-id="me"]).is-single-message {
+    border-top-left-radius: var(--border-radius-lg);
+    border-bottom-left-radius: var(--border-radius-lg);
 }
 
 .message-time {
@@ -3161,6 +3207,28 @@ body.dark-mode .chat-ad-summary:hover {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-xs);
+    position: relative;
+}
+
+.offer-card::before {
+    content: "\f0d6";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    margin-right: var(--spacing-xs);
+}
+
+.appointment-card::before {
+    content: "\f073";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    margin-right: var(--spacing-xs);
+}
+
+.location-card::before {
+    content: "\f3c5";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    margin-right: var(--spacing-xs);
 }
 
 .offer-actions, .appointment-actions {


### PR DESCRIPTION
## Summary
- validate metadata fields for offers and appointments in `messageModel`
- disable send button unless text or image is provided
- preview attached images with cancel option
- update message grouping logic and styling
- style interactive message cards with icons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d8094606c832e9fbb43137552af93