### PR TITLE
Refactor messaging for optimistic UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1044,6 +1044,7 @@
                                     <div class="message-content">
                                         <p class="message-text"></p>
                                         <time class="message-time"></time>
+                                        <div class="message-status-icons"></div>
                                         <span class="read-indicator hidden">✔✔</span>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- make Message post-save hook non-blocking
- send socket events immediately in controller
- add optimistic message rendering on client
- show message status icons and resend on failure

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dca2e6bf0832eb049d3db4db998e9