### PR TITLE
Refactor messaging backend and frontend

### DIFF
--- a/middlewares/validationMiddleware.js
+++ b/middlewares/validationMiddleware.js
@@ -163,33 +163,19 @@ const updateAdSchema = Joi.object({
 
 // Schéma pour l'envoi de message texte
 const createMessageSchema = Joi.object({
-    threadId: Joi.string().hex().length(24).optional(),
-    recipientId: Joi.string().hex().length(24).optional(),
-    adId: Joi.string().hex().length(24).when('threadId', {
-        is: Joi.exist(),
-        then: Joi.optional(),
-        otherwise: Joi.required()
-    }),
-    text: Joi.string().trim().allow('').max(2000).messages({
-        'string.max': 'Le message ne doit pas dépasser {#limit} caractères.'
-    })
-    .when(Joi.object({ threadId: Joi.not().exist() }), {
-        then: Joi.required() // Requis seulement pour les nouveaux threads
-    })
-}).xor('threadId', 'recipientId');
+    threadId: Joi.string().hex().length(24).required(),
+    text: Joi.string().trim().allow('').max(2000).optional(),
+    type: Joi.string().optional(),
+    metadata: Joi.any().optional(),
+    tempId: Joi.string().optional()
+});
 
 // Schéma pour l'envoi de message avec image (où le texte est optionnel)
 const sendMessageWithImageSchema = Joi.object({
-    threadId: Joi.string().hex().length(24).optional(),
-    recipientId: Joi.string().hex().length(24).optional(),
-    adId: Joi.string().hex().length(24).when('threadId', {
-        is: Joi.exist(),
-        then: Joi.optional(),
-        otherwise: Joi.required()
-    }),
-    // Pour cette route, le texte est optionnel car l'image est la donnée principale
-    text: Joi.string().trim().allow('').max(2000).optional()
-}).xor('threadId', 'recipientId');
+    threadId: Joi.string().hex().length(24).required(),
+    text: Joi.string().trim().allow('').max(2000).optional(),
+    tempId: Joi.string().optional()
+});
 
 
 

--- a/models/messageModel.js
+++ b/models/messageModel.js
@@ -90,47 +90,6 @@ const messageSchema = new mongoose.Schema({
 // Index pour trier les messages par date de création dans un thread
 messageSchema.index({ threadId: 1, createdAt: -1 });
 
-// Après qu'un message est sauvegardé, mettre à jour le champ `lastMessage` et `updatedAt` du Thread parent.
-// Et potentiellement incrémenter le `unreadCount` pour le(s) destinataire(s).
-messageSchema.post('save', function(doc, next) {
-    // Appel immédiat de next() pour ne pas bloquer le contrôleur
-    next();
-
-    // Lancement des opérations de mise à jour en arrière-plan sans attendre la fin
-    (async () => {
-        try {
-            const Thread = mongoose.model('Thread'); // Éviter les problèmes d'import circulaire
-            const User = mongoose.model('User');
-
-            const thread = await Thread.findById(doc.threadId);
-            if (thread) {
-                // La logique de mise à jour du thread reste la même
-                thread.lastMessage = {
-                    text: doc.text,
-                    sender: doc.senderId,
-                    createdAt: doc.createdAt,
-                    imageUrl: doc.imageUrl,
-                };
-                thread.updatedAt = doc.createdAt;
-
-                thread.participants.forEach(participant => {
-                    if (participant.user.toString() !== doc.senderId.toString()) {
-                        participant.unreadCount = (participant.unreadCount || 0) + 1;
-                    }
-                    if (participant.locallyDeletedAt) {
-                        participant.locallyDeletedAt = undefined;
-                    }
-                });
-
-                await thread.save();
-                // Note : L'émission Socket.IO sera maintenant gérée par le contrôleur.
-            }
-        } catch (error) {
-            // Logguer l'erreur de la tâche de fond sans impacter la réponse à l'utilisateur
-            console.error("Erreur dans le post-save hook (tâche de fond) de Message pour mettre à jour le Thread:", error);
-        }
-    })();
-});
 
 
 const Message = mongoose.model('Message', messageSchema);


### PR DESCRIPTION
## Summary
- remove message post-save hook
- update message send logic to require existing thread and emit via socket
- ensure threads are revived when initiating
- enhance frontend chat initiation and UI status
- add real-time newThread and messagesRead handlers
- implement textarea auto-height and validation updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dfa99c584832e89f1f43e8f83c27e