### PR TITLE
Improve chat interface with read receipts and header overhaul

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1001,25 +1001,26 @@
 
                     <div id="chat-view" class="messages-view">
                         <div class="modal-header chat-header">
-                            <button id="back-to-threads-btn" type="button" class="btn btn-icon"
-                                aria-label="Retour aux discussions">
+                            <button id="back-to-threads-btn" type="button" class="btn btn-icon" aria-label="Retour aux discussions">
                                 <i class="fa-solid fa-arrow-left"></i>
                             </button>
-                            <img id="chat-recipient-avatar" src="avatar-default.svg" alt="Avatar de l'interlocuteur"
-                                class="chat-recipient-avatar"
-                                onerror="this.src='https://placehold.co/36x36/e0e0e0/757575?text=User';">
-                            <div class="chat-recipient-info">
-                                <h2 id="chat-recipient-name" class="modal-title chat-title"></h2>
-                                <span id="chat-recipient-status" class="chat-recipient-status"></span>
+
+                            <div id="chat-recipient-info-block" class="chat-recipient" role="button" tabindex="0" aria-label="Voir le profil de l'utilisateur">
+                                <img id="chat-recipient-avatar" src="avatar-default.svg" alt="Avatar de l'interlocuteur" class="chat-recipient-avatar" onerror="this.src='https://placehold.co/36x36/e0e0e0/757575?text=User';">
+                                <div class="chat-recipient-details">
+                                    <h2 id="chat-recipient-name" class="modal-title chat-title"></h2>
+                                    <span id="chat-recipient-status" class="chat-recipient-status"></span>
+                                </div>
                             </div>
-                            <button id="chat-options-btn" type="button" class="btn btn-icon"
-                                aria-label="Options du chat" aria-haspopup="true" aria-expanded="false">
-                                <i class="fa-solid fa-ellipsis-v"></i>
-                            </button>
-                            <div id="chat-options-menu" class="dropdown-menu hidden" role="menu">
-                                <button role="menuitem" id="block-user-chat-btn"
-                                    data-i18n="chat.blockUser">Bloquer</button>
-                                <button role="menuitem" id="delete-chat-btn" data-i18n="chat.delete">Supprimer</button>
+
+                            <div class="chat-header-actions">
+                                <button id="chat-options-btn" type="button" class="btn btn-icon" aria-label="Options du chat" aria-haspopup="true" aria-expanded="false">
+                                    <i class="fa-solid fa-ellipsis-v"></i>
+                                </button>
+                                <div id="chat-options-menu" class="dropdown-menu hidden" role="menu">
+                                    <button role="menuitem" id="block-user-chat-btn" data-i18n="chat.blockUser">Bloquer</button>
+                                    <button role="menuitem" id="delete-chat-btn" data-i18n="chat.delete">Supprimer</button>
+                                </div>
                             </div>
                         </div>
                         <div id="chat-ad-summary" class="chat-ad-summary">
@@ -1043,9 +1044,15 @@
                                 <div class="chat-message" data-message-id="">
                                     <div class="message-content">
                                         <p class="message-text"></p>
-                                        <time class="message-time"></time>
-                                        <div class="message-status-icons"></div>
-                                        <span class="read-indicator hidden">✔✔</span>
+                                        <div class="message-meta">
+                                            <time class="message-time"></time>
+                                            <span class="message-status-icons" aria-label="Statut du message"></span>
+                                        </div>
+                                    </div>
+                                    <div class="message-tail">
+                                        <svg viewBox="0 0 12 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M0 12V0C8.83445 0 12 3.16555 12 12H0Z"/>
+                                        </svg>
                                     </div>
                                 </div>
                             </template>

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -573,7 +573,6 @@ function renderMessages(messages, method) {
         const textEl = messageEl.querySelector('.message-text');
         const timeEl = messageEl.querySelector('.message-time');
         const statusEl = messageEl.querySelector('.message-status-icons');
-        const readEl = messageEl.querySelector('.read-indicator');
 
         if (msg._id) messageEl.dataset.messageId = msg._id;
         if (msg.tempId) messageEl.dataset.tempId = msg.tempId;
@@ -658,32 +657,39 @@ function renderMessages(messages, method) {
 
         timeEl.textContent = formatDate(msg.createdAt, { hour: '2-digit', minute: '2-digit' });
 
-        if (isSentByMe) {
+        if (isSentByMe && statusEl) {
+            statusEl.innerHTML = '';
+            let icon;
+            let title = '';
+
             switch (msg.status) {
                 case 'sending':
-                    statusEl.innerHTML = '<i class="fa-regular fa-clock"></i>';
+                    icon = 'fa-regular fa-clock';
+                    title = 'Envoi en cours...';
                     messageEl.classList.add('sending-message');
                     break;
                 case 'sent':
-                    statusEl.innerHTML = '<i class="fa-solid fa-check"></i>';
+                    icon = 'fa-solid fa-check';
+                    title = 'Envoyé';
                     break;
                 case 'read':
-                    statusEl.innerHTML = '<i class="fa-solid fa-check-double"></i>';
+                    icon = 'fa-solid fa-check-double';
+                    title = 'Lu';
                     break;
                 case 'failed_to_send':
                 case 'failed':
-                    statusEl.innerHTML = '<i class="fa-solid fa-circle-exclamation text-danger"></i>';
+                    icon = 'fa-solid fa-circle-exclamation';
+                    title = 'Échec de l\'envoi';
                     messageEl.classList.add('message-failed');
+                    if(statusEl) statusEl.style.color = 'var(--danger-color)';
                     break;
-                default:
-                    statusEl.innerHTML = '';
             }
-        }
 
-        if (isSentByMe && msg.status === 'read') {
-            readEl.classList.remove('hidden');
-        } else {
-            readEl.classList.add('hidden');
+            if (icon) {
+                statusEl.innerHTML = `<i class="${icon}" title="${title}"></i>`;
+            }
+        } else if (statusEl) {
+            statusEl.innerHTML = '';
         }
         fragment.appendChild(clone);
         lastDay = msgDayKey;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1893,29 +1893,6 @@ h4 {
     border-bottom-left-radius: var(--border-radius-xs);
 }
 
-.chat-message[data-sender-id="me"]::after,
-.chat-message:not([data-sender-id="me"])::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    width: 0;
-    height: 0;
-    border: 8px solid transparent;
-}
-
-.chat-message[data-sender-id="me"]::after {
-    right: -8px;
-    border-left-color: var(--primary-color);
-    border-right: 0;
-}
-
-.chat-message:not([data-sender-id="me"])::after {
-    left: -8px;
-    border-right-color: var(--gray-200);
-    border-left: 0;
-}
-
-
 .chat-message.is-first-in-group {
     margin-top: var(--spacing-sm);
 }
@@ -1965,44 +1942,7 @@ h4 {
     border-bottom-left-radius: var(--border-radius-lg);
 }
 
-/* Cache la queue par défaut */
-.chat-message::after {
-    display: none;
-}
 
-/* Affiche la queue seulement pour le dernier message d'un groupe ou un message unique */
-.chat-message.is-last-in-group::after,
-.chat-message.is-single-message::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    width: 0;
-    height: 0;
-    border: 8px solid transparent;
-    display: block; /* Rendre la queue visible */
-}
-
-/* Positionne la queue à droite pour les messages envoyés */
-.chat-message[data-sender-id="me"].is-last-in-group::after,
-.chat-message[data-sender-id="me"].is-single-message::after {
-    right: -8px;
-    border-left-color: var(--primary-color);
-    border-right: 0;
-}
-
-/* Positionne la queue à gauche pour les messages reçus */
-.chat-message:not([data-sender-id="me"]).is-last-in-group::after,
-.chat-message:not([data-sender-id="me"]).is-single-message::after {
-    left: -8px;
-    border-right-color: var(--gray-200);
-    border-left: 0;
-}
-
-/* En mode sombre */
-body.dark-mode .chat-message:not([data-sender-id="me"]).is-last-in-group::after,
-body.dark-mode .chat-message:not([data-sender-id="me"]).is-single-message::after {
-    border-right-color: var(--gray-700);
-}
 
 /* Ajustements de border-radius pour un look de messagerie */
 .chat-message[data-sender-id="me"].is-first-in-group { border-bottom-right-radius: var(--border-radius-xs); }
@@ -3602,3 +3542,121 @@ body.dark-mode .owner-actions-panel {
 }
 
 /* Le style .btn-danger-outline est déjà dans votre CSS, parfait ! */
+
+/* ===== New & Improved Chat Styles ===== */
+
+/* 1. Meta container for time and status */
+.message-meta {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    font-size: 0.75rem;
+    color: var(--gray-400);
+    margin-top: 4px;
+    gap: 4px;
+}
+
+.chat-message[data-sender-id="me"] .message-meta {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+/* 2. Status Icons (Read Receipts) */
+.message-status-icons {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+}
+
+.message-status-icons i {
+    font-size: 0.8em;
+}
+
+.message-status-icons .fa-check-double {
+    color: #4fc3f7;
+}
+
+.chat-message:not([data-sender-id="me"]) .message-status-icons {
+    display: none;
+}
+
+/* 3. SVG Message Bubble Tail */
+.message-tail {
+    position: absolute;
+    bottom: 0;
+    width: 12px;
+    height: 12px;
+    display: none;
+}
+
+.chat-message.is-last-in-group .message-tail,
+.chat-message.is-single-message .message-tail {
+    display: block;
+}
+
+.chat-message[data-sender-id="me"] .message-tail {
+    right: -10px;
+    color: var(--primary-color);
+}
+
+.chat-message:not([data-sender-id="me"]) .message-tail {
+    left: -10px;
+    transform: scaleX(-1);
+    color: var(--gray-200);
+}
+
+body.dark-mode .chat-message:not([data-sender-id="me"]) .message-tail {
+    color: var(--gray-700);
+}
+
+/* 4. Chat Header Reorganization Styles */
+.chat-header {
+    justify-content: space-between;
+}
+
+.chat-recipient {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    flex-grow: 1;
+    min-width: 0;
+    cursor: pointer;
+    padding: var(--spacing-xs);
+    border-radius: var(--border-radius-md);
+    transition: background-color var(--transition-duration-short);
+}
+
+.chat-recipient:hover, .chat-recipient:focus {
+    background-color: var(--gray-100);
+}
+body.dark-mode .chat-recipient:hover, body.dark-mode .chat-recipient:focus {
+    background-color: var(--gray-700);
+}
+
+.chat-recipient-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+.chat-recipient-details {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.chat-header .chat-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0;
+}
+
+.chat-header-actions {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
- restructure chat header for better layout
- redesign chat message template with SVG tail and meta container
- add CSS for new chat features and remove outdated pseudo-elements
- update message rendering logic to show status icons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e0629cc7c832eaea84b50a675a4be