### PR TITLE
Fix favorites placeholder to match notifications

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -794,10 +794,8 @@
                     <div class="modal-body" id="favorites-list-container"
                         data-firestore-collection="users/{userId}/favorites">
                         <div id="no-favorites-placeholder" class="placeholder-message hidden">
-                            <i class="fa-regular fa-heart fa-3x"></i>
-                            <p data-i18n="favorites.noFavorites">Vous n'avez pas encore de favoris.</p>
-                            <p><small data-i18n="favorites.howToAdd">Cliquez sur <i class="fa-solid fa-heart"></i> sur
-                                    une annonce pour l'ajouter.</small></p>
+                            <i class="fa-solid fa-bell-slash fa-3x"></i>
+                            <p>Aucun favori pour le moment.</p>
                         </div>
                         <ul id="favorites-list" class="item-list">
                             <template id="favorite-item-template">


### PR DESCRIPTION
## Summary
- update the empty favorites placeholder to mimic the notification modal style

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e0c29dcbc832e89b77f1e8ee9c067