### PR TITLE
Add realtime unread message counts

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -558,6 +558,14 @@ async function checkInitialAuthState() {
                 const userData = response.data.user;
                 state.setCurrentUser(userData);
                 updateUIAfterLogin(userData);
+
+                // Charger le décompte initial de messages non lus
+                secureFetch('/api/messages/threads/unread-count', {}, false)
+                    .then(countResponse => {
+                        if (countResponse && countResponse.success) {
+                            state.set('messages.unreadGlobalCount', countResponse.data.unreadCount);
+                        }
+                    });
                 console.log('Utilisateur authentifié via token existant:', userData.name);
 
                 if (!userData.emailVerified) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -3762,3 +3762,31 @@ body.dark-mode .chat-recipient:hover, body.dark-mode .chat-recipient:focus {
     align-items: center;
     justify-content: flex-end;
 }
+
+/* Styles pour les conversations non lues */
+.thread-item.thread-unread .thread-item__ad-title,
+.thread-item.thread-unread .thread-item__user-name {
+    font-weight: 700;
+    color: var(--text-color-headings);
+}
+
+.thread-item.thread-unread .thread-item__message-preview {
+    color: var(--text-color-base);
+    font-weight: 500;
+}
+
+.thread-meta .unread-badge {
+    background-color: var(--primary-color);
+    color: white;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: bold;
+    min-width: 20px;
+    text-align: center;
+    transition: transform 0.2s ease;
+}
+
+.thread-meta .unread-badge.hidden {
+    transform: scale(0);
+}

--- a/routes/messageRoutes.js
+++ b/routes/messageRoutes.js
@@ -14,6 +14,7 @@ router.use(protect);
 // Routes pour les Threads
 router.post('/threads/initiate', validateInitiateThread, messageController.initiateOrGetThread);
 router.get('/threads', messageController.getMyThreads);
+router.get('/threads/unread-count', messageController.getUnreadThreadCount);
 router.get('/threads/:threadId/messages', messageController.getMessagesForThread);
 router.post('/threads/:threadId/read', messageController.markThreadAsRead);
 router.delete('/threads/:threadId/local', messageController.deleteThreadLocally); // Suppression locale


### PR DESCRIPTION
## Summary
- add endpoint to fetch unread conversation count
- push unread count with newMessage events
- return unread count when marking a thread as read
- update frontend auth flow to fetch initial unread count
- handle realtime unread count updates in messaging UI
- style unread threads and badges

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684eab50b2f4832ebb91b6387f0c5e7b