### PR TITLE
Improve messaging read tracking & typing indicator

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -363,6 +363,8 @@ exports.sendMessage = asyncHandler(async (req, res, next) => {
                 'participants.unreadCount': { $gt: 0 }
             });
 
+            logger.info(`Envoi du nouveau décompte de threads non lus (${totalUnreadCountForParticipant}) à l'utilisateur ${participantId}`);
+
             ioInstance.of('/chat').to(room).emit('newMessage', {
                 message: messageObj,
                 thread: thread.toObject(),
@@ -407,6 +409,8 @@ exports.markThreadAsRead = asyncHandler(async (req, res, next) => {
         { $set: { status: 'read' } }
     );
 
+    logger.info(`Thread ${threadId}: ${updateResult.modifiedCount} message(s) marqué(s) comme lu(s) pour le destinataire ${userId}.`);
+
     // Si des messages ont été mis à jour, notifier l'autre participant
     if (updateResult.modifiedCount > 0) {
         const otherParticipant = thread.participants.find(p => p.user.toString() !== userId);
@@ -424,6 +428,8 @@ exports.markThreadAsRead = asyncHandler(async (req, res, next) => {
         'participants.user': userId,
         'participants.unreadCount': { $gt: 0 }
     });
+
+    logger.info(`Envoi du décompte de threads non lus mis à jour (${totalUnreadCount}) à l'utilisateur ${userId}`);
 
     res.status(200).json({
         success: true,

--- a/public/styles.css
+++ b/public/styles.css
@@ -1892,6 +1892,19 @@ h4 {
     box-shadow: var(--shadow-xs); /* Ajouter une ombre légère */
 }
 
+.chat-message.sending {
+    opacity: 0.7;
+    background-color: var(--gray-400);
+}
+
+.chat-message.message-failed {
+    background-color: var(--danger-color-light, #fee2e2);
+    border: 1px solid var(--danger-color);
+}
+.message-failed .message-text {
+    color: var(--danger-color-dark);
+}
+
 
 .chat-message[data-sender-id="me"] {
     background-color: var(--primary-color);

--- a/server.js
+++ b/server.js
@@ -267,6 +267,13 @@ io.of(SOCKET_NAMESPACE).on('connection', (socket) => {
         }
     });
 
+    socket.on('typing', ({ threadId, isTyping }) => {
+        if (threadId) {
+            const room = `thread_${threadId}`;
+            socket.to(room).emit('typing', { threadId, userName: socket.user.name, isTyping });
+        }
+    });
+
     socket.on('disconnect', async (reason) => {
         logger.info(`Socket.IO: Utilisateur déconnecté du namespace /chat: ${socket.id}. Raison: ${reason}`);
         await User.findByIdAndUpdate(socket.user.id, { isOnline: false, lastSeen: new Date() });


### PR DESCRIPTION
## Summary
- log unread thread counts and messages read
- emit readerId with messagesRead
- display status icons using FontAwesome
- add sending/failure styles
- handle typing events and update UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684eafc23ef4832eb90c3eef74750415