### PR TITLE
Improve toast UX and clean error handling

### DIFF
--- a/public/js/ads.js
+++ b/public/js/ads.js
@@ -1385,13 +1385,17 @@ async function handleDeleteUserAd(adId) {
             cancelText: 'Annuler',   // Texte pour le bouton d'annulation
             isDestructive: true,     // Pour styler le bouton de confirmation en rouge
             onConfirm: async () => {
-                toggleGlobalLoader(true, "Suppression de l'annonce...");
+                const card = document.getElementById(adId);
+                card?.classList.add('is-loading');
                 try {
                     const response = await secureFetch(`${API_BASE_URL}/${adId}`, { method: 'DELETE' }, false);
-                    toggleGlobalLoader(false);
                     if (response && response.success) {
-                        showToast("Annonce supprimée avec succès.", "success");
-                        fetchAndRenderUserAds(); // Recharger la liste des annonces de l'utilisateur
+                        showToast("Annonce supprimée avec succès", "success");
+                        if (card) {
+                            card.classList.add('fade-out');
+                            card.addEventListener('animationend', () => card.remove(), { once: true });
+                        }
+                        fetchAndRenderUserAds();
                         if (typeof state.refreshAds === 'function') {
                             state.refreshAds();
                         } else {
@@ -1401,9 +1405,9 @@ async function handleDeleteUserAd(adId) {
                         showToast(response.message || "Erreur lors de la suppression de l'annonce.", "error");
                     }
                 } catch (error) {
-                    toggleGlobalLoader(false);
                     console.error("Erreur lors de la suppression de l'annonce:", error);
-                    showToast(error.message || "Une erreur technique est survenue.", "error");
+                } finally {
+                    card?.classList.remove('is-loading');
                 }
             }
         }

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -288,8 +288,7 @@ async function handleLogin(event) {
     } catch (error) {
         toggleGlobalLoader(false); // Masquer le loader en cas d'erreur
         console.error('Erreur détaillée lors de la connexion (capturée dans handleLogin):', error);
-        // error.message devrait contenir le message d'erreur du serveur si secureFetch le propage.
-        showToast(error.message || 'Une erreur de connexion est survenue.', 'error');
+        // secureFetch gère l'affichage de l'erreur
     }
 }
 
@@ -352,7 +351,7 @@ async function handleSignup(event) {
     } catch (error) {
         toggleGlobalLoader(false);
         console.error('Erreur détaillée lors de l\'inscription (capturée dans handleSignup):', error);
-        showToast(error.message || 'Une erreur de communication est survenue durant l\'inscription.', 'error');
+        // secureFetch se charge d'afficher l'erreur
     }
 }
 
@@ -488,7 +487,6 @@ function performLocalLogout() {
     state.setCurrentUser(null); // Met à jour l'état global
     state.resetState(true); // Réinitialise l'état en gardant les préférences UI
     updateUIAfterLogout();
-    showToast('Vous avez été déconnecté.', 'info');
 
     // Fermer toutes les modales qui nécessitent une authentification
     // et potentiellement rediriger vers la page d'accueil ou de connexion.
@@ -598,7 +596,7 @@ async function checkInitialAuthState() {
             // pour lesquelles secureFetch ou d'autres parties pourraient déjà afficher un message.
             // Une 404 sur /api/auth/me est une erreur serveur critique, mais le client doit se déconnecter.
             if (!(error.message.includes('401') || error.message.includes('403'))) {
-                 showToast("Votre session n'a pas pu être vérifiée. Veuillez vous reconnecter.", "error");
+                 // secureFetch a déjà affiché l'erreur pour 401/403
             }
         }
     } else {

--- a/public/js/favorites.js
+++ b/public/js/favorites.js
@@ -144,10 +144,10 @@ async function handleToggleFavoriteEvent(event) {
     // Appel API et restauration de l'état en cas d'échec
     const success = setFavorite ? await addFavorite(adId) : await removeFavorite(adId);
     if (!success) {
-        showToast("L'opération a échoué, restauration de l'état précédent.", "error");
         state.set('favorites', previousFavorites);
         if (sourceButton) animateFavoriteButton(sourceButton, !setFavorite);
     }
+    return success;
 }
 
 /**
@@ -163,9 +163,7 @@ async function addFavorite(adId) {
         }, false);
 
         if (response && response.success) {
-            showToast("Annonce ajoutée aux favoris !", "success");
             state.addFavorite(adId);
-            // Recharger les favoris pour être sûr d'avoir les données à jour
             loadUserFavorites();
             return true;
         }
@@ -188,10 +186,7 @@ async function removeFavorite(adId) {
         }, false);
 
         if (response && response.success) {
-            showToast("Annonce retirée des favoris.", "info");
             state.removeFavorite(adId);
-            // Le changement d'état a déjà été fait de manière optimiste.
-            // On peut recharger pour confirmer la synchronisation.
             loadUserFavorites();
             return true;
         }

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -808,6 +808,12 @@ async function _sendPayload(payload, imageFile = null) {
     const messageInputBeforeSend = chatMessageInput.value;
     const imageFileBeforeSend = tempImageFile;
 
+    const originalButtonContent = sendChatMessageBtn ? sendChatMessageBtn.innerHTML : '';
+    if (sendChatMessageBtn) {
+        sendChatMessageBtn.disabled = true;
+        sendChatMessageBtn.innerHTML = '<span class="spinner"></span>';
+    }
+
     chatMessageInput.value = '';
     removeImagePreview();
     stopTypingEvent();
@@ -837,6 +843,11 @@ async function _sendPayload(payload, imageFile = null) {
             if (statusContainer) {
                 statusContainer.innerHTML = '<i class="fa-solid fa-circle-exclamation text-danger" title="Échec de l\'envoi"></i>';
             }
+        }
+    } finally {
+        if (sendChatMessageBtn) {
+            sendChatMessageBtn.disabled = false;
+            sendChatMessageBtn.innerHTML = originalButtonContent;
         }
     }
 }

--- a/public/js/profile.js
+++ b/public/js/profile.js
@@ -163,7 +163,6 @@ async function loadProfileData() {
             populateProfileFields(currentUser);
         }
     } catch (error) {
-        showToast(error.message || "Erreur critique lors du chargement du profil.", "error");
         document.dispatchEvent(new CustomEvent('mapmarket:closeModal', { detail: { modalId: 'profile-modal' } }));
     }
 }
@@ -255,7 +254,7 @@ async function handleAvatarUpload(fileToUpload) {
     try {
         const response = await secureFetch(`${API_BASE_URL_USERS}/avatar`, { method: 'POST', body: formData }, false);
         if (response && response.success && response.data.avatarUrl) {
-            showToast("Avatar mis à jour !", "success");
+            showToast("Avatar mis à jour.", "success");
             const currentUser = state.getCurrentUser();
             if (currentUser) {
                 state.setCurrentUser({ ...currentUser, avatarUrl: response.data.avatarUrl });
@@ -264,7 +263,6 @@ async function handleAvatarUpload(fileToUpload) {
         }
         throw new Error(response.message || "Erreur de mise à jour de l'avatar.");
     } catch (error) {
-        showToast(error.message, "error");
         const currentUser = state.getCurrentUser();
         if (currentUser) populateProfileFields(currentUser);
         return false;
@@ -291,7 +289,6 @@ async function handleRemoveAvatar() {
                         }
                     } else throw new Error(response.message);
                 } catch (error) {
-                    showToast(error.message || "Erreur de suppression.", "error");
                 } finally {
                     toggleGlobalLoader(false);
                 }
@@ -387,7 +384,7 @@ async function handleProfileUpdate(event) {
             // La réponse du backend est déjà gérée par secureFetch en cas d'erreur
             // On vérifie juste le succès pour la suite.
             if (response && response.success) {
-                showToast("Mot de passe mis à jour avec succès !", "success");
+                showToast("Mot de passe mis à jour.", "success");
                 // Le backend envoie un nouveau token, mettons-le à jour
                 if(response.token) {
                     localStorage.setItem('mapmarket_auth_token', response.token);
@@ -399,7 +396,6 @@ async function handleProfileUpdate(event) {
             }
 
         } catch (error) {
-            showToast(error.message, "error");
             toggleGlobalLoader(false);
             return; // On arrête tout si la mise à jour du mot de passe échoue
         } finally {
@@ -421,7 +417,7 @@ async function handleProfileUpdate(event) {
 
             if (response && response.success && response.data.user) {
                 if (!passwordUpdated) { // N'affiche ce toast que si seul le nom a été changé
-                    showToast("Nom d'utilisateur mis à jour !", "success");
+                    showToast("Profil mis à jour.", "success");
                 }
                 state.setCurrentUser(response.data.user); // Met à jour l'état local avec les nouvelles données
                 profileUpdated = true;
@@ -429,7 +425,6 @@ async function handleProfileUpdate(event) {
                  throw new Error(response.message || "La mise à jour du profil a échoué.");
             }
         } catch (error) {
-            showToast(error.message, "error");
             // On ne stoppe pas ici, car le mot de passe a peut-être été mis à jour avec succès.
         } finally {
             toggleGlobalLoader(false);
@@ -469,7 +464,6 @@ async function performAccountDeactivation() {
             logout(); // Gère la déconnexion et le nettoyage local
         } else throw new Error(response.message);
     } catch (error) {
-        showToast(error.message || "Erreur de suppression.", "error");
     } finally {
         toggleGlobalLoader(false);
     }

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -235,7 +235,6 @@ async function handlePushNotificationsToggle() {
             }
         } catch (error) {
             console.error("Settings: Erreur d'abonnement Push:", error);
-            showToast("Erreur lors de l'activation des notifications push.", "error");
             pushNotificationsToggle.checked = false; localStorage.setItem('mapMarketPushPreference', 'false');
         }
     } else { // Désactivation
@@ -255,7 +254,6 @@ async function handlePushNotificationsToggle() {
             }
         } catch (error) {
             console.error("Settings: Erreur de désabonnement Push:", error);
-            showToast("Erreur lors de la désactivation des notifications push.", "error");
             pushNotificationsToggle.checked = true; // Remettre en cas d'erreur
         }
         localStorage.setItem('mapMarketPushPreference', 'false');
@@ -341,7 +339,6 @@ async function saveUserSetting(key, value) {
 
     } catch (error) {
         console.error(`Erreur lors de la sauvegarde de la préférence '${key}' sur le serveur:`, error);
-        showToast(`Échec de la sauvegarde de la préférence '${key}'.`, "error");
         // Optionnel: annuler le changement UI si la sauvegarde échoue ?
         // Par exemple, pour un toggle: toggleElement.checked = !toggleElement.checked;
     }


### PR DESCRIPTION
## Summary
- queue toasts and add icons in utils
- centralize secureFetch error handling
- remove redundant catch toasts in auth, profile and settings modules
- refine success messages
- show spinner and disable send button in chat while sending
- enhance ad deletion with loading state and fade-out animation
- streamline favorites logic without toast spam

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684edba5267c832eb3322c65763947e1