### PR TITLE
Implement local currency engine

### DIFF
--- a/public/js/favorites.js
+++ b/public/js/favorites.js
@@ -14,7 +14,7 @@ import {
     secureFetch,
     toggleGlobalLoader,
     sanitizeHTML,
-    formatPrice
+    formatCurrency
 } from './utils.js';
 
 const API_BASE_URL = '/api/favorites';
@@ -243,7 +243,7 @@ function renderFavoritesListWithData(favoriteAdsData) {
             img.alt = `Image de ${sanitizeHTML(ad.title)}`;
         }
         if (title) title.textContent = sanitizeHTML(ad.title);
-        if (price) price.textContent = ad.price != null ? formatPrice(ad.price, ad.currency) : 'N/A';
+        if (price) price.textContent = ad.price != null ? formatCurrency(ad.price, ad.currency) : 'N/A';
         const categoryObj = state.getCategories().find(c => c.id === ad.category);
         if (category) category.textContent = categoryObj ? sanitizeHTML(categoryObj.name) : sanitizeHTML(ad.category);
 

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -12,7 +12,7 @@ import {
     showToast,
     toggleGlobalLoader,
     sanitizeHTML,
-    formatPrice,
+    formatCurrency,
     getQueryParam,
     debounce,
     calculateDistance
@@ -586,7 +586,7 @@ function showAdPreviewCard(ad) {
         image.alt = `Image de ${sanitizeHTML(ad.title)}`;
     }
     if (title) title.textContent = sanitizeHTML(ad.title);
-    if (price) price.textContent = ad.price != null ? formatPrice(ad.price, ad.currency) : 'N/A';
+    if (price) price.textContent = ad.price != null ? formatCurrency(ad.price, ad.currency) : 'N/A';
 
     const categories = state.getCategories ? state.getCategories() : [];
     const catObj = categories.find(c => c.id === ad.category);
@@ -684,7 +684,7 @@ export function renderAdsInListView() {
         if (title) title.textContent = ad.title;
         
         const price = listItem.querySelector('.item-price');
-        if(price) price.textContent = formatPrice(ad.price, ad.currency);
+        if(price) price.textContent = formatCurrency(ad.price, ad.currency);
 
         // Retirer les actions d'édition/suppression car ce ne sont pas les annonces de l'utilisateur
         listItem.querySelector('.my-ad-actions')?.remove();

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -14,7 +14,7 @@ import {
     toggleGlobalLoader,
     sanitizeHTML,
     formatDate,
-    formatPrice,
+    formatCurrency,
     generateUUID
 } from './utils.js';
 
@@ -403,7 +403,7 @@ async function openChatView(threadId, recipient, threadData = null) {
 
         if(thumb) thumb.src = (adForSummary.imageUrls && adForSummary.imageUrls[0]) ? adForSummary.imageUrls[0] : 'https://placehold.co/60x60/e0e0e0/757575?text=Ad';
         if(link) link.textContent = sanitizeHTML(adForSummary.title);
-        if(price) price.textContent = formatPrice(adForSummary.price, adForSummary.currency);
+        if(price) price.textContent = formatCurrency(adForSummary.price, adForSummary.currency);
         
         link.onclick = (e) => {
             e.preventDefault();
@@ -887,7 +887,7 @@ async function sendOfferMessage(amount) {
     if (!val) { showToast('Montant invalide', 'warning'); return; }
     const payload = {
         type: 'offer',
-        text: `Offre: ${formatPrice(val, 'EUR')}`,
+        text: `Offre: ${formatCurrency(val, 'EUR')}`,
         metadata: { amount: val, currency: 'EUR', status: 'pending' }
     };
     if (activeThreadId) {

--- a/utils/geoDatabase.js
+++ b/utils/geoDatabase.js
@@ -1,0 +1,55 @@
+/**
+ * @description Base de données locale des pays avec leur code, devise et boîte englobante.
+ * La boîte englobante (bbox) est un tableau [minLongitude, minLatitude, maxLongitude, maxLatitude].
+ * C'est une approximation qui couvre la majorité du territoire d'un pays.
+ * Vous pouvez enrichir ce tableau avec autant de pays que nécessaire.
+ */
+const countriesData = [
+  {
+    countryCode: 'TN',
+    currency: 'TND', // Dinar Tunisien
+    bbox: [7.5, 30.2, 11.6, 37.6]
+  },
+  {
+    countryCode: 'FR',
+    currency: 'EUR', // Euro
+    bbox: [-5.15, 41.3, 9.6, 51.2] // France métropolitaine
+  },
+  {
+    countryCode: 'MA',
+    currency: 'MAD', // Dirham Marocain
+    bbox: [-17.2, 21.0, -1.0, 35.9]
+  },
+  {
+    countryCode: 'DZ',
+    currency: 'DZD', // Dinar Algérien
+    bbox: [-8.67, 18.96, 11.99, 37.09]
+  },
+  {
+    countryCode: 'CH',
+    currency: 'CHF', // Franc Suisse
+    bbox: [5.96, 45.82, 10.49, 47.81]
+  },
+  // Ajoutez d'autres pays ici...
+];
+
+/**
+ * @description Trouve la devise correspondant à des coordonnées géographiques.
+ * Itère sur notre base de données locale et vérifie si les coordonnées
+ * se trouvent dans la boîte englobante d'un des pays.
+ * @param {number} lat Latitude
+ * @param {number} lon Longitude
+ * @returns {string|null} Le code de la devise (ex: 'TND') ou null si aucun pays n'est trouvé.
+ */
+function findCurrencyByCoords(lat, lon) {
+  for (const country of countriesData) {
+    const [minLon, minLat, maxLon, maxLat] = country.bbox;
+    if (lon >= minLon && lon <= maxLon && lat >= minLat && lat <= maxLat) {
+      return country.currency;
+    }
+  }
+  return null; // Aucune devise trouvée pour ces coordonnées
+}
+
+// Exporte la fonction pour qu'elle soit utilisable dans les contrôleurs
+module.exports = { findCurrencyByCoords };


### PR DESCRIPTION
## Summary
- add local geo database for currency lookup
- derive ad currency from coordinates on create & update
- display ad prices with correct currency across UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f006355e8832ea69f060835eff745