### PR TITLE
Implement soft delete for conversations with confirmation modal

### DIFF
--- a/models/threadModel.js
+++ b/models/threadModel.js
@@ -26,7 +26,7 @@ const threadSchema = new mongoose.Schema({
         required: false,
     },
     hiddenFor: [{
-        type: mongoose.Schema.ObjectId,
+        type: mongoose.Schema.Types.ObjectId,
         ref: 'User'
     }],
     lastMessage: {

--- a/public/js/modals.js
+++ b/public/js/modals.js
@@ -357,6 +357,42 @@ function updatePreviewCardFavoriteIcon(adId) {
         if (favoriteBtn) favoriteBtn.classList.toggle('active', isFavorite);
     }
 }
+
+// Modal de confirmation simplifié (version dynamique)
+export function showConfirmationModal({ title, message, confirmText = 'Confirmer', cancelText = 'Annuler', onConfirm }) {
+  const existing = document.getElementById('confirmation-modal-overlay');
+  if (existing) existing.remove();
+
+  const modalOverlay = document.createElement('div');
+  modalOverlay.id = 'confirmation-modal-overlay';
+  modalOverlay.className = 'modal-overlay';
+
+  modalOverlay.innerHTML = `
+    <div class="modal-content" id="confirmation-modal-content">
+      <h4>${title}</h4>
+      <p>${message}</p>
+      <div class="modal-actions">
+        <button id="modal-cancel" class="btn btn-flat">${cancelText}</button>
+        <button id="modal-confirm" class="btn btn-danger">${confirmText}</button>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(modalOverlay);
+
+  const closeModal = () => modalOverlay.remove();
+  modalOverlay.querySelector('#modal-confirm').onclick = () => {
+    if (typeof onConfirm === 'function') onConfirm();
+    closeModal();
+  };
+  modalOverlay.querySelector('#modal-cancel').onclick = closeModal;
+
+  modalOverlay.addEventListener('click', (e) => {
+    if (e.target.id === 'confirmation-modal-overlay') {
+      closeModal();
+    }
+  });
+}
 function handleCloseModalEvent(event) {
     const { modalId } = event.detail;
     if (modalId) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -3809,3 +3809,47 @@ body.dark-mode .chat-recipient:hover, body.dark-mode .chat-recipient:focus {
   display: none !important;
 }
 
+/* Styles pour le modal de confirmation */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1050;
+}
+.modal-overlay .modal-content {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+.modal-overlay .modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+/* Styles pour l'animation de suppression de conversation */
+.thread-item {
+  transition: all 0.4s ease-in-out;
+  overflow: hidden;
+}
+.thread-item.fade-out-and-collapse {
+  opacity: 0;
+  transform: translateX(-30px);
+  max-height: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  border: none !important;
+}
+

--- a/routes/messageRoutes.js
+++ b/routes/messageRoutes.js
@@ -17,7 +17,9 @@ router.get('/threads', messageController.getMyThreads);
 router.get('/threads/unread-count', messageController.getUnreadThreadCount);
 router.get('/threads/:threadId/messages', messageController.getMessagesForThread);
 router.post('/threads/:threadId/read', messageController.markThreadAsRead);
-router.patch('/threads/:threadId/local', messageController.deleteThreadLocally); // Suppression locale
+router.patch('/threads/:threadId/local', messageController.hideThreadForUser); // Suppression locale (legacy)
+router.route('/threads/:threadId')
+  .delete(messageController.hideThreadForUser);
 
 // Routes pour les Messages
 router.post('/messages', validateCreateMessage, messageController.sendMessage); // Pour les messages texte


### PR DESCRIPTION
## Summary
- add hiddenFor field using ObjectId type for threads
- allow users to hide threads instead of deleting them
- expose `DELETE /threads/:threadId` route
- add generic `showConfirmationModal` helper
- implement fade-out animation and modal styles
- update messages UI to confirm hide and animate removal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a3e066c832eb999aba2f92eb6ae