### PR TITLE
Implement socket.io realtime chat

### DIFF
--- a/controllers/threadController.js
+++ b/controllers/threadController.js
@@ -1,0 +1,57 @@
+const Thread = require('../models/threadModel');
+const Message = require('../models/messageModel');
+const Ad = require('../models/adModel');
+const { AppError } = require('../middlewares/errorHandler');
+
+const asyncHandler = fn => (req,res,next)=>Promise.resolve(fn(req,res,next)).catch(next);
+
+/**
+ * Crée ou récupère un thread pour une annonce spécifique.
+ * L'utilisateur connecté devient l'acheteur.
+ */
+exports.createOrGetThread = asyncHandler(async (req,res,next)=>{
+    const buyerId = req.user.id;
+    const { adId } = req.body;
+    if(!adId) return next(new AppError('adId requis',400));
+    const ad = await Ad.findById(adId).select('seller');
+    if(!ad) return next(new AppError('Annonce introuvable',404));
+    const sellerId = ad.seller.toString();
+
+    let thread = await Thread.findOne({
+        ad: adId,
+        'participants.user': { $all: [buyerId, sellerId] },
+        participants: { $size: 2 }
+    });
+
+    if(!thread){
+        thread = await Thread.create({
+            participants:[{user:buyerId},{user:sellerId}],
+            ad: adId
+        });
+    }
+
+    thread = await Thread.findById(thread._id)
+        .populate('participants.user','name avatarUrl')
+        .populate('ad');
+
+    res.status(200).json({ success:true, data:{ thread }});
+});
+
+/**
+ * Récupère les threads de l'utilisateur courant avec dernier message et nombre de messages non lus.
+ */
+exports.getThreadsForUser = asyncHandler(async (req,res,next)=>{
+    const userId = req.user.id;
+    const threads = await Thread.find({ 'participants.user': userId })
+        .populate('participants.user','name avatarUrl')
+        .populate('ad');
+
+    const data = await Promise.all(threads.map(async t=>{
+        const lastMessage = await Message.findOne({ threadId:t._id }).sort({createdAt:-1});
+        const unread = await Message.countDocuments({ threadId:t._id, senderId:{ $ne:userId }, status:{ $ne:'read' } });
+        return { ...t.toObject(), lastMessage, unreadCount: unread };
+    }));
+
+    res.status(200).json({ success:true, data:{ threads: data }});
+});
+

--- a/models/messageModel.js
+++ b/models/messageModel.js
@@ -20,9 +20,19 @@ const messageSchema = new mongoose.Schema({
     //     ref: 'User',
     //     required: true,
     // },
+    /**
+     * Type de contenu principal du message.
+     * Conservé pour rétrocompatibilité mais "contentType" est désormais
+     * utilisé par les nouvelles fonctionnalités temps réel.
+     */
     type: {
         type: String,
         enum: ['text', 'image', 'offer', 'appointment', 'location', 'system'],
+        default: 'text'
+    },
+    contentType: {
+        type: String,
+        enum: ['text', 'image', 'location', 'appointment'],
         default: 'text'
     },
     metadata: {
@@ -56,6 +66,14 @@ const messageSchema = new mongoose.Schema({
     imageUrl: {
         type: String,
         trim: true,
+    },
+    location: {
+        latitude: Number,
+        longitude: Number,
+    },
+    appointment: {
+        date: Date,
+        details: String,
     },
     status: {
         type: String,
@@ -95,3 +113,4 @@ messageSchema.index({ threadId: 1, createdAt: -1 });
 const Message = mongoose.model('Message', messageSchema);
 
 module.exports = Message;
+

--- a/models/threadModel.js
+++ b/models/threadModel.js
@@ -29,11 +29,10 @@ const threadSchema = new mongoose.Schema({
         type: mongoose.Schema.ObjectId,
         ref: 'User'
     }],
+    // Référence vers le dernier message pour accélérer les requêtes
     lastMessage: {
-        text: String,
-        sender: { type: mongoose.Schema.ObjectId, ref: 'User' },
-        createdAt: Date,
-        imageUrl: String,
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Message'
     },
 }, {
     timestamps: true,
@@ -80,3 +79,4 @@ threadSchema.statics.findOrCreateThread = async function(userId1, userId2, adId 
 const Thread = mongoose.model('Thread', threadSchema);
 
 module.exports = Thread;
+

--- a/public/styles.css
+++ b/public/styles.css
@@ -3606,3 +3606,23 @@ body.dark-mode .chat-recipient:hover, body.dark-mode .chat-recipient:focus {
   display: none !important;
 }
 
+/* Styles simplifiés pour le chat temps réel */
+.message.sender {
+    background-color: var(--primary-color);
+    color: #fff;
+    margin-left: auto;
+    text-align: right;
+    border-radius: var(--border-radius-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    max-width: 70%;
+}
+.message.receiver {
+    background-color: var(--gray-200);
+    color: var(--text-color-base);
+    margin-right: auto;
+    text-align: left;
+    border-radius: var(--border-radius-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    max-width: 70%;
+}
+

--- a/routes/threadRoutes.js
+++ b/routes/threadRoutes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const threadController = require('../controllers/threadController');
+const { protect } = require('../middlewares/authMiddleware');
+
+const router = express.Router();
+
+router.use(protect);
+
+router.post('/', threadController.createOrGetThread);
+router.get('/', threadController.getThreadsForUser);
+
+module.exports = router;
+


### PR DESCRIPTION
## Summary
- add realtime socket events in server
- add Thread controller and routes
- enhance message and thread models
- integrate socket events on frontend
- add CSS helpers for chat messages
- enforce thread access checks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685008064454832e93c295e8e8f686a0