### PR TITLE
Fix socket initialization in messages module

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -23,7 +23,8 @@ import * as PWA from './pwa.js';
 import * as Onboarding from './onboarding.js';
 import * as History from './history.js';
 
-export const socket = io();
+// La connexion Socket.IO est désormais gérée dans messages.js pour éviter les
+// dépendances circulaires.
 import * as Settings from './settings.js';
 import * as NotificationsDisplay from './notifications.js';
 


### PR DESCRIPTION
## Summary
- remove exported socket instance from `main.js`
- manage socket connection locally inside `messages.js`
- avoid early access to `socket` before initialization
- register realtime message listener after socket connection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68501ec45c68832e92dbbe751652b877