### PR TITLE
Fix verify access endpoint for messages

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -194,6 +194,27 @@ exports.getUnreadThreadCount = asyncHandler(async (req, res, next) => {
     });
 });
 
+/**
+ * Vérifie que l'utilisateur connecté est bien participant du thread.
+ * GET /api/messages/threads/:threadId/verify-access
+ */
+exports.verifyThreadAccess = asyncHandler(async (req, res, next) => {
+    const { threadId } = req.params;
+    const userId = req.user.id;
+
+    const thread = await Thread.findById(threadId).select('participants');
+    if (!thread) {
+        return next(new AppError('Conversation non trouvée.', 404));
+    }
+
+    const isParticipant = thread.participants.some(p => p.user.toString() === userId);
+    if (!isParticipant) {
+        return next(new AppError('Accès non autorisé à cette conversation.', 403));
+    }
+
+    res.status(200).json({ success: true });
+});
+
 
 /**
  * Construit l'URL complète pour l'image d'un message.

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -255,7 +255,6 @@ async function openChatView(threadId, recipient, threadData = null) {
             }
         } catch (error) {
             console.error("Erreur de vérification d'accès:", error);
-            showToast("Erreur de chargement de la conversation.", "error");
             return showThreadList();
         }
     }

--- a/routes/messageRoutes.js
+++ b/routes/messageRoutes.js
@@ -15,6 +15,7 @@ router.use(protect);
 router.post('/threads/initiate', validateInitiateThread, messageController.initiateOrGetThread);
 router.get('/threads', messageController.getMyThreads);
 router.get('/threads/unread-count', messageController.getUnreadThreadCount);
+router.get('/threads/:threadId/verify-access', messageController.verifyThreadAccess);
 router.get('/threads/:threadId/messages', messageController.getMessagesForThread);
 router.post('/threads/:threadId/read', messageController.markThreadAsRead);
 router.patch('/threads/:threadId/local', messageController.deleteThreadLocally); // Suppression locale


### PR DESCRIPTION
## Summary
- add a new route `/threads/:threadId/verify-access`
- implement controller logic to check if current user participates in the thread
- clean up openChatView error handling on frontend

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68507e93ee70832e841e2743770cba2a