### PR TITLE
Fix chat messages container initialization

### DIFF
--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -98,14 +98,54 @@ function initializeUI() {
     };
 
     let allFound = true;
+    const found = {};
     for (const [key, id] of Object.entries(elements)) {
         const element = document.getElementById(id);
         if (!element) {
             console.error(`Élément critique de la messagerie manquant: #${id}`);
             allFound = false;
         }
-        window[key] = element; // Assign to global scope
+        found[key] = element;
     }
+
+    ({
+        messagesModal,
+        threadListView,
+        chatView,
+        threadListUl,
+        threadItemTemplate,
+        noThreadsPlaceholder,
+        backToThreadsBtn,
+        chatRecipientAvatar,
+        chatRecipientName,
+        chatRecipientStatus,
+        chatOptionsBtn,
+        chatOptionsMenu,
+        blockUserChatBtn,
+        deleteChatBtn,
+        chatMessagesContainer,
+        chatMessageTemplate,
+        chatHistoryLoader,
+        chatTypingIndicator,
+        chatInputArea,
+        chatMessageInput,
+        sendChatMessageBtn,
+        messagesNavBadge,
+        navMessagesBtn,
+        chatComposerBtn,
+        chatComposerMenu,
+        chatAttachImageBtn,
+        chatImageUploadInput,
+        chatImagePreviewContainer,
+        chatMakeOfferBtn,
+        chatShareLocationBtn,
+        chatMeetBtn,
+        offerModal,
+        submitOfferBtn,
+        appointmentModal,
+        submitAppointmentBtn,
+        threadsTabs
+    } = found);
 
     if (sendChatMessageBtn) sendChatMessageBtn.disabled = true;
 


### PR DESCRIPTION
## Summary
- correctly store DOM elements for messages UI instead of using global window object
- prevent `chatMessagesContainer` from being undefined when opening chat view

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685081a81904832e990a9b99837b6dcf