### PR TITLE
Fix service worker and remove incorrect socket.io import

### DIFF
--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -4,7 +4,7 @@
  * Cette version supprime tout le polling et repose sur la communication en temps réel.
  */
 
-import io from 'socket.io-client';
+// Socket.IO est chargé via le CDN dans index.html et exposé globalement sous la variable `io`.
 import * as state from './state.js';
 import { fetchInitialUnreadCount } from './main.js';
 import {

--- a/public/sw.js
+++ b/public/sw.js
@@ -156,7 +156,12 @@ self.addEventListener('fetch', (event) => {
                 // On vérifie le type de ressource demandé pour fournir un fallback approprié.
                 if (event.request.destination === 'image') {
                     // Si c'est une image, on retourne l'image de secours qui a été mise en cache.
-                    return caches.match('/images/placeholder-image.svg');
+                    return caches.match('/images/placeholder-image.svg')
+                        .then(fallback => fallback || new Response('Image indisponible', {
+                            status: 404,
+                            statusText: 'Not Found',
+                            headers: { 'Content-Type': 'text/plain' }
+                        }));
                 }
                 
                 // Pour tout autre cas (ex: un script ou une police qui n'a pas pu être chargé),


### PR DESCRIPTION
## Summary
- fix fetch fallback in service worker to always return a Response
- remove unused `socket.io-client` module import in `messages.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68512e1d2358832e9d7be1a997db1b8e