### PR TITLE
Add realtime favorite notifications

### DIFF
--- a/models/notificationModel.js
+++ b/models/notificationModel.js
@@ -8,6 +8,10 @@ const notificationSchema = new mongoose.Schema({
         required: [true, 'Une notification doit être destinée à un utilisateur.'],
         index: true,
     },
+    senderId: { // L'utilisateur qui déclenche la notification
+        type: mongoose.Schema.ObjectId,
+        ref: 'User',
+    },
     title: {
         type: String,
         required: [true, 'Le titre de la notification est requis.'],
@@ -33,6 +37,7 @@ const notificationSchema = new mongoose.Schema({
             'welcome',
             'password_reset_success',
             'email_verified_success',
+            'new_favorite',
             // Ajoutez d'autres types selon les besoins
         ],
         required: [true, 'Le type de notification est requis.'],

--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,7 @@
                         <span id="notifications-badge" class="badge notification-badge" aria-hidden="true"
                             data-count="0">0</span>
                     </button>
+                    <div id="notification-list" class="notification-dropdown hidden" role="menu"></div>
 
                     <button id="header-profile-btn" class="header-action-btn" type="button"
                         aria-label="Ouvrir le menu utilisateur" aria-expanded="false" data-user-logged-in="false">

--- a/public/js/notifications.js
+++ b/public/js/notifications.js
@@ -18,24 +18,35 @@ const API_BASE_URL = '/api/notifications';
 
 // --- Éléments du DOM ---
 let notificationsPanel, notificationsListContainer, notificationItemTemplate, noNotificationsPlaceholder;
-let notificationsBadgeHeader; // Badge sur le bouton de l'en-tête
+let notificationsBadgeHeader;
+let notificationDropdown;
+let socket = null;
 let markAllAsReadBtn, clearAllNotificationsBtn; // Boutons potentiels dans le panel
 
 // --- État du module ---
 // Les notifications sont stockées dans state.js: state.notifications.list et state.notifications.unreadCount
 
+function connectSocket() {
+    const token = localStorage.getItem('mapmarket_auth_token');
+    if (!token || socket) return;
+    socket = io({ auth: { token } });
+    socket.on('new_notification', (notif) => {
+        handleNewNotificationEvent({ detail: { notificationData: notif } });
+    });
+}
+
 /**
  * Initialise les éléments du DOM et les écouteurs d'événements pour les notifications.
  */
 export function init() {
-    notificationsPanel = document.getElementById('notifications-panel'); // C'est une modale dans index.html
-    // Le contenu des notifications sera dans le modal-body de notifications-panel
-    notificationsListContainer = notificationsPanel ? notificationsPanel.querySelector('.modal-body') : null;
+    notificationsPanel = document.getElementById('notifications-panel');
+    notificationDropdown = document.getElementById('notification-list');
+    notificationsListContainer = notificationDropdown;
     // Il faudra un template pour les items de notification dans le HTML, ou le créer dynamiquement.
     // Pour l'instant, on va le créer dynamiquement si non trouvé.
     notificationItemTemplate = document.getElementById('notification-item-template'); // À ajouter au HTML
 
-    noNotificationsPlaceholder = document.getElementById('no-notifications-placeholder'); // À ajouter au HTML
+    noNotificationsPlaceholder = document.getElementById('no-notifications-placeholder');
     notificationsBadgeHeader = document.getElementById('notifications-badge');
 
     // Boutons optionnels à ajouter dans le panel des notifications
@@ -47,20 +58,29 @@ export function init() {
         // Ne pas bloquer le reste de l'app si le panel n'est pas critique au démarrage.
     }
 
+    const currentUser = state.getCurrentUser();
+    if (currentUser) {
+        connectSocket();
+        loadUserNotifications();
+    } else {
+        updateNotificationsBadge(0);
+    }
+
     // Écouteurs d'événements
     const headerNotificationsBtn = document.getElementById('header-notifications-btn');
-    if (headerNotificationsBtn) {
+    if (headerNotificationsBtn && notificationDropdown) {
         headerNotificationsBtn.addEventListener('click', () => {
-            // L'ouverture de la modale est gérée par modals.js via aria-controls
-            // On s'assure de charger les notifications à l'ouverture.
+            const hidden = notificationDropdown.classList.contains('hidden');
+            if (hidden) {
+                loadUserNotifications();
+                notificationDropdown.classList.remove('hidden');
+                setTimeout(markVisibleNotificationsAsRead, 3000);
+            } else {
+                notificationDropdown.classList.add('hidden');
+            }
         });
     }
 
-    document.addEventListener('mapMarket:modalOpened', (event) => {
-        if (event.detail.modalId === 'notifications-panel') {
-            handleOpenNotificationsPanel();
-        }
-    });
 
     // S'abonner aux changements de l'état des notifications
     state.subscribe('notificationsChanged', (notificationsState) => {
@@ -73,15 +93,7 @@ export function init() {
     // Écouteur pour un événement de nouvelle notification (dispatché par SW pour Push ou par messages.js, alerts.js etc.)
     document.addEventListener('mapMarket:newNotification', handleNewNotificationEvent);
 
-    // Charger les notifications initiales et le compteur
-    const currentUser = state.getCurrentUser();
-    if (currentUser) {
-        loadUserNotifications();
-    } else {
-        updateNotificationsBadge(0); // Pas de notifs si pas connecté
-    }
-
-    // Initialiser le badge avec la valeur de l'état (au cas où elle serait déjà là)
+    // Initialiser le badge avec la valeur actuelle
     updateNotificationsBadge(state.get('notifications.unreadCount') || 0);
 
 
@@ -394,6 +406,29 @@ async function markNotificationAsRead(notificationId) {
             // Pour l'instant, on garde l'optimisme côté client.
             showToast("Erreur de synchronisation du statut de la notification.", "error");
         }
+    }
+}
+
+async function markVisibleNotificationsAsRead() {
+    if (!notificationDropdown) return;
+    const unreadEls = notificationDropdown.querySelectorAll('.notification-item.unread');
+    const ids = Array.from(unreadEls).map(el => el.dataset.notificationId);
+    if (ids.length === 0) return;
+    try {
+        await secureFetch(`${API_BASE_URL}/mark-as-read`, {
+            method: 'POST',
+            body: { notificationIds: ids }
+        }, false);
+        ids.forEach(id => {
+            const n = state.get('notifications.list').find(n => n.id === id);
+            if (n) n.isRead = true;
+        });
+        state.set('notifications', {
+            list: state.get('notifications.list'),
+            unreadCount: Math.max(0, state.get('notifications.unreadCount') - ids.length)
+        });
+    } catch (e) {
+        console.error('Erreur mark-as-read', e);
     }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1697,6 +1697,33 @@ h4 {
     background-color: var(--gray-100);
 }
 
+#notification-list {
+    position: absolute;
+    right: var(--spacing-md);
+    top: calc(var(--header-height) + var(--spacing-sm));
+    background-color: var(--component-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-md);
+    box-shadow: var(--shadow-lg);
+    z-index: 10;
+    max-height: 300px;
+    overflow-y: auto;
+    width: 300px;
+}
+
+#notification-list .notification-item {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-bottom: 1px solid var(--border-color);
+}
+
+#notification-list .notification-item.unread {
+    background-color: var(--gray-100);
+}
+
+#notification-list.hidden {
+    display: none;
+}
+
 .chat-messages-body {
     padding: var(--spacing-md);
     display: flex;

--- a/routes/notificationRoutes.js
+++ b/routes/notificationRoutes.js
@@ -11,6 +11,8 @@ router.use(protect);
 router.route('/')
     .get(notificationController.getMyNotifications); // Récupérer toutes les notifications de l'utilisateur
 
+router.post('/mark-as-read', notificationController.markMultipleNotificationsAsRead);
+
 router.post('/read-all', notificationController.markAllNotificationsAsRead); // Marquer toutes comme lues
 
 router.route('/:id')


### PR DESCRIPTION
## Summary
- attach authenticated Socket.IO root namespace and track sockets per user
- extend Notification schema with senderId and `new_favorite` type
- send realtime notification when a user favorites an ad
- expose `POST /api/notifications/mark-as-read`
- emit `new_notification` events from notification creator
- add dropdown UI for notifications with WebSocket support

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685bf097db0c8324837ed8fa5922b045