### PR TITLE
Fix ReactNode import

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import apiClient from '../lib/apiClient';
 
 interface User {


### PR DESCRIPTION
## Summary
- adjust AuthContext import to work with `verbatimModuleSyntax`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685f170137748324805685f69875d4f2