### PR TITLE
Remove email verification flow

### DIFF
--- a/controllers/settingController.js
+++ b/controllers/settingController.js
@@ -80,8 +80,6 @@ exports.updateMySettings = asyncHandler(async (req, res, next) => {
     delete userResponse.passwordChangedAt;
     delete userResponse.passwordResetToken;
     delete userResponse.passwordResetExpires;
-    delete userResponse.emailVerificationToken;
-    delete userResponse.emailVerificationExpires;
 
 
     logger.info(`Paramètres mis à jour pour l'utilisateur ${userId}: ${JSON.stringify(settings)}`);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -346,8 +346,6 @@ exports.deactivateMyAccount = asyncHandler(async (req, res, next) => {
   // Invalider les tokens de réinitialisation et de vérification pour un compte désactivé
   user.passwordResetToken = undefined;
   user.passwordResetExpires = undefined;
-  user.emailVerificationToken = undefined;
-  user.emailVerificationExpires = undefined;
   // Optionnel: changer l'email pour libérer l'email actuel si nécessaire pour une réinscription future
   // user.email = `deactivated-${Date.now()}-${user.email}`; 
   // Attention: ceci rendrait la réactivation plus complexe si l'email original n'est pas stocké ailleurs.

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -80,21 +80,6 @@ exports.protect = async (req, res, next) => {
   }
 };
 
-/**
- * Middleware pour vérifier si l'email de l'utilisateur est validé.
- * À utiliser sur les routes qui nécessitent une validation d'email.
- */
-exports.isEmailVerified = (req, res, next) => {
-    if (!req.user) { // Doit être utilisé après le middleware `protect`
-        return next(new AppError('Utilisateur non authentifié.', 401));
-    }
-    if (!req.user.emailVerified) {
-        return next(
-            new AppError('Veuillez vérifier votre adresse e-mail pour accéder à cette fonctionnalité.', 403) // 403 Forbidden
-        );
-    }
-    next();
-};
 
 
 /**

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -56,12 +56,6 @@ const userSchema = new mongoose.Schema({
         default: true,
         select: false,
     },
-    emailVerified: {
-        type: Boolean,
-        default: false,
-    },
-    emailVerificationToken: String,
-    emailVerificationExpires: Date,
 
     passwordChangedAt: Date,
     passwordResetToken: String,
@@ -188,14 +182,6 @@ const createToken = function() {
     return token; // Retourner le token non hashé (à envoyer à l'utilisateur)
 };
 
-userSchema.methods.createEmailVerificationToken = function() {
-    const verificationToken = createToken.call({ _id: this._id }); // Utiliser call pour lier 'this' correctement
-    
-    this.emailVerificationToken = crypto.createHash('sha256').update(verificationToken).digest('hex');
-    this.emailVerificationExpires = Date.now() + 24 * 60 * 60 * 1000; // 24 heures
-
-    return verificationToken;
-};
 
 userSchema.methods.createPasswordResetToken = function() {
     const resetToken = createToken.call({ _id: this._id });

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,7 +1,7 @@
 // routes/authRoutes.js
 const express = require('express');
 const authController = require('../controllers/authController'); // Sera créé ensuite
-const { protect, isEmailVerified } = require('../middlewares/authMiddleware');
+const { protect } = require('../middlewares/authMiddleware');
 const { authRateLimiter } = require('../config/rateLimit'); // Limiteur de taux pour l'auth
 const { validateSignup, validateLogin, validateForgotPassword, validateResetPassword } = require('../middlewares/validationMiddleware'); // Sera créé ensuite
 
@@ -13,9 +13,6 @@ router.post('/login', authRateLimiter, validateLogin, authController.login);
 router.post('/forgot-password', authRateLimiter, validateForgotPassword, authController.forgotPassword);
 router.patch('/reset-password/:token', authRateLimiter, validateResetPassword, authController.resetPassword); // Utiliser PATCH car on modifie une ressource (le mot de passe)
 
-router.get('/validate-email/:token', authController.validateEmail);
-router.post('/resend-validation-email', protect, authController.resendValidationEmail); // L'utilisateur doit être connecté pour renvoyer son propre email de validation
-// Elle définit la route que votre frontend essaie d'appeler
 router.patch('/update-password', protect, authController.updatePassword);
 
 // Route pour vérifier le statut de connexion (optionnel, utile pour le frontend)


### PR DESCRIPTION
## Summary
- drop email verification fields from user model
- streamline signup and login controllers
- remove email verification routes and middleware
- tidy up controllers for settings and user
- simplify frontend auth logic to skip verification

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68614259b9f88324b3cd81df76f431fc