### PR TITLE
Add admin panel backend and frontend

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,0 +1,107 @@
+const User = require('../models/userModel');
+const Ad = require('../models/adModel');
+const { AppError } = require('../middlewares/errorHandler');
+const APIFeatures = require('../utils/apiFeatures');
+
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+// Dashboard statistics
+exports.getDashboardStats = asyncHandler(async (req, res, next) => {
+  const totalUsers = await User.countDocuments();
+  const totalAds = await Ad.countDocuments();
+  const recentUsers = await User.find().sort({ createdAt: -1 }).limit(5);
+  const recentAds = await Ad.find().sort({ createdAt: -1 }).limit(5).populate('userId', 'name');
+
+  res.status(200).json({
+    status: 'success',
+    data: { totalUsers, totalAds, recentUsers, recentAds }
+  });
+});
+
+// Users management
+exports.getAllUsers = asyncHandler(async (req, res, next) => {
+  const features = new APIFeatures(User.find(), req.query)
+    .filter()
+    .sort()
+    .limitFields()
+    .paginate();
+
+  const users = await features.query;
+
+  res.status(200).json({
+    status: 'success',
+    results: users.length,
+    data: { users }
+  });
+});
+
+exports.updateUser = asyncHandler(async (req, res, next) => {
+  const filteredBody = {
+    name: req.body.name,
+    role: req.body.role,
+    isActive: req.body.isActive
+  };
+
+  const updatedUser = await User.findByIdAndUpdate(req.params.id, filteredBody, {
+    new: true,
+    runValidators: true
+  });
+
+  if (!updatedUser) {
+    return next(new AppError('Utilisateur introuvable.', 404));
+  }
+
+  res.status(200).json({ status: 'success', data: { user: updatedUser } });
+});
+
+exports.deleteUser = asyncHandler(async (req, res, next) => {
+  const user = await User.findByIdAndDelete(req.params.id);
+
+  if (!user) {
+    return next(new AppError('Utilisateur introuvable.', 404));
+  }
+
+  res.status(204).json({ status: 'success', data: null });
+});
+
+// Ads management
+exports.getAllAds = asyncHandler(async (req, res, next) => {
+  const features = new APIFeatures(Ad.find().populate('userId', 'name email'), req.query)
+    .filter()
+    .sort()
+    .limitFields()
+    .paginate();
+
+  const ads = await features.query;
+
+  res.status(200).json({
+    status: 'success',
+    results: ads.length,
+    data: { ads }
+  });
+});
+
+exports.updateAd = asyncHandler(async (req, res, next) => {
+  const updatedAd = await Ad.findByIdAndUpdate(req.params.id, req.body, {
+    new: true,
+    runValidators: true
+  });
+
+  if (!updatedAd) {
+    return next(new AppError('Annonce introuvable.', 404));
+  }
+
+  res.status(200).json({ status: 'success', data: { ad: updatedAd } });
+});
+
+exports.deleteAd = asyncHandler(async (req, res, next) => {
+  const ad = await Ad.findByIdAndDelete(req.params.id);
+
+  if (!ad) {
+    return next(new AppError('Annonce introuvable.', 404));
+  }
+
+  res.status(204).json({ status: 'success', data: null });
+});

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -83,6 +83,16 @@ exports.protect = async (req, res, next) => {
 
 
 /**
+ * Vérifie que l'utilisateur authentifié possède le rôle administrateur.
+ */
+exports.isAdmin = (req, res, next) => {
+  if (!req.user || req.user.role !== 'admin') {
+    return next(new AppError('Accès refusé. Droits administrateur requis.', 403));
+  }
+  next();
+};
+
+/**
  * Restreint l'accès à certains rôles (si vous implémentez des rôles).
  * Exemple: exports.restrictTo = (...roles) => { ... }
  * Pour l'instant, on n'a pas de système de rôles complexe.

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapMarket - Panneau d'Administration</title>
+    <link rel="stylesheet" href="/css/admin.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <div class="admin-container">
+        <nav class="admin-sidebar">
+            <h1 class="sidebar-title">MapMarket</h1>
+            <ul class="sidebar-nav">
+                <li><a href="#dashboard" class="nav-link active">Dashboard</a></li>
+                <li><a href="#users" class="nav-link">Utilisateurs</a></li>
+                <li><a href="#ads" class="nav-link">Annonces</a></li>
+                <li><a href="#categories" class="nav-link">Catégories</a></li>
+                <li><a href="#settings" class="nav-link">Paramètres</a></li>
+            </ul>
+            <div class="sidebar-footer">
+                <button id="logout-btn" class="logout-button">Déconnexion</button>
+            </div>
+        </nav>
+        <main class="admin-content" id="admin-main-content">
+            <p>Chargement...</p>
+        </main>
+    </div>
+
+    <div id="confirmation-modal" class="modal-hidden">
+        <div class="modal-content">
+            <h2>Confirmation requise</h2>
+            <p id="modal-text">Êtes-vous sûr de vouloir effectuer cette action ?</p>
+            <div class="modal-actions">
+                <button id="confirm-action-btn" class="btn-danger">Confirmer</button>
+                <button id="cancel-action-btn" class="btn-secondary">Annuler</button>
+            </div>
+        </div>
+    </div>
+
+    <script type="module" src="/js/admin.js"></script>
+</body>
+</html>

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -1,0 +1,188 @@
+:root {
+    --primary-color: #3498db;
+    --dark-blue: #2c3e50;
+    --light-gray: #ecf0f1;
+    --medium-gray: #bdc3c7;
+    --white: #ffffff;
+    --danger-color: #e74c3c;
+    --success-color: #2ecc71;
+}
+
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    background-color: var(--light-gray);
+    color: var(--dark-blue);
+}
+
+.admin-container {
+    display: flex;
+    min-height: 100vh;
+}
+
+.admin-sidebar {
+    width: 250px;
+    background-color: var(--dark-blue);
+    color: var(--white);
+    display: flex;
+    flex-direction: column;
+    padding: 1.5rem;
+    position: fixed;
+    height: 100%;
+}
+
+.sidebar-title {
+    text-align: center;
+    margin-top: 0;
+    font-size: 1.8rem;
+    color: var(--primary-color);
+}
+
+.sidebar-nav {
+    list-style-type: none;
+    padding: 0;
+    margin-top: 2rem;
+    flex-grow: 1;
+}
+
+.sidebar-nav .nav-link {
+    display: block;
+    color: var(--light-gray);
+    text-decoration: none;
+    padding: 1rem;
+    border-radius: 5px;
+    margin-bottom: 0.5rem;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.sidebar-nav .nav-link:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+.sidebar-nav .nav-link.active {
+    background-color: var(--primary-color);
+    color: var(--white);
+}
+
+.sidebar-footer {
+    margin-top: auto;
+}
+
+.logout-button {
+    width: 100%;
+    padding: 1rem;
+    background-color: var(--danger-color);
+    border: none;
+    color: var(--white);
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: bold;
+}
+
+.admin-content {
+    flex-grow: 1;
+    margin-left: 250px;
+    padding: 2rem;
+}
+
+.content-header {
+    font-size: 2rem;
+    margin-top: 0;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--medium-gray);
+    margin-bottom: 2rem;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.widget {
+    background-color: var(--white);
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+}
+
+.widget-title {
+    margin-top: 0;
+    font-size: 1.2rem;
+    color: var(--medium-gray);
+}
+
+.widget-value {
+    font-size: 2.5rem;
+    font-weight: bold;
+    margin: 0.5rem 0;
+}
+
+.table-container {
+    background-color: var(--white);
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+    overflow-x: auto;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+    padding: 1rem;
+    text-align: left;
+    border-bottom: 1px solid var(--light-gray);
+}
+
+.data-table th {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    color: var(--medium-gray);
+}
+
+.table-actions button {
+    margin-right: 0.5rem;
+    padding: 0.4rem 0.8rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.btn-edit { background-color: #f39c12; color: white; }
+.btn-delete { background-color: var(--danger-color); color: white; }
+
+.modal-hidden { display: none; }
+.modal-visible {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.modal-content {
+    background-color: var(--white);
+    padding: 2rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+}
+
+.modal-actions {
+    margin-top: 1.5rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+}
+
+.btn-danger { background-color: var(--danger-color); color: white; border: none; padding: 0.7rem 1.2rem; border-radius: 5px; cursor: pointer; }
+.btn-secondary { background-color: var(--medium-gray); color: white; border: none; padding: 0.7rem 1.2rem; border-radius: 5px; cursor: pointer; }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1,0 +1,195 @@
+import { secureFetch } from './utils.js';
+
+const token = localStorage.getItem('mapmarket_auth_token');
+if (!token) {
+    window.location.replace('/index.html');
+}
+
+const mainContent = document.getElementById('admin-main-content');
+const navLinks = document.querySelectorAll('.nav-link');
+
+const routes = {
+    '#dashboard': renderDashboard,
+    '#users': renderUsers,
+    '#ads': renderAds,
+    '#categories': () => { mainContent.innerHTML = '<h1>Catégories</h1><p>Section en construction.</p>'; },
+    '#settings': () => { mainContent.innerHTML = '<h1>Paramètres</h1><p>Section en construction.</p>'; }
+};
+
+async function router() {
+    const hash = window.location.hash || '#dashboard';
+    const handler = routes[hash];
+
+    navLinks.forEach(link => {
+        if (link.getAttribute('href') === hash) {
+            link.classList.add('active');
+        } else {
+            link.classList.remove('active');
+        }
+    });
+
+    if (handler) {
+        try {
+            mainContent.innerHTML = '<p>Chargement...</p>';
+            await handler();
+        } catch (err) {
+            console.error(err);
+            if (err.status === 403) {
+                mainContent.innerHTML = '<h1>Accès refusé</h1>';
+            } else {
+                mainContent.innerHTML = '<h1>Erreur</h1>';
+            }
+        }
+    }
+}
+
+async function renderDashboard() {
+    const res = await secureFetch('/api/admin/stats');
+    const { totalUsers, totalAds, recentUsers, recentAds } = res.data;
+
+    mainContent.innerHTML = `
+        <h1 class="content-header">Dashboard</h1>
+        <div class="dashboard-grid">
+            <div class="widget">
+                <h2 class="widget-title">Utilisateurs</h2>
+                <p class="widget-value">${totalUsers}</p>
+            </div>
+            <div class="widget">
+                <h2 class="widget-title">Annonces</h2>
+                <p class="widget-value">${totalAds}</p>
+            </div>
+        </div>
+        <div class="dashboard-grid" style="margin-top: 2rem;">
+            <div class="table-container">
+                <h2>Derniers Utilisateurs</h2>
+                <ul style="list-style: none; padding: 0;">
+                    ${recentUsers.map(u => `<li>${u.name} - ${u.email}</li>`).join('')}
+                </ul>
+            </div>
+            <div class="table-container">
+                <h2>Dernières Annonces</h2>
+                <ul style="list-style: none; padding: 0;">
+                    ${recentAds.map(a => `<li>${a.title} (par ${a.userId ? a.userId.name : 'N/A'})</li>`).join('')}
+                </ul>
+            </div>
+        </div>
+    `;
+}
+
+async function renderUsers() {
+    const res = await secureFetch('/api/admin/users');
+    const users = res.data.users;
+
+    mainContent.innerHTML = `
+        <h1 class="content-header">Gestion des Utilisateurs</h1>
+        <div class="table-container">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Nom</th>
+                        <th>Email</th>
+                        <th>Rôle</th>
+                        <th>Actif</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${users.map(u => `
+                        <tr data-id="${u._id}">
+                            <td>${u.name}</td>
+                            <td>${u.email}</td>
+                            <td>${u.role}</td>
+                            <td>${u.isActive ? 'Oui' : 'Non'}</td>
+                            <td class="table-actions">
+                                <button class="btn-delete">Supprimer</button>
+                            </td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        </div>
+    `;
+}
+
+async function renderAds() {
+    const res = await secureFetch('/api/admin/ads');
+    const ads = res.data.ads;
+
+    mainContent.innerHTML = `
+        <h1 class="content-header">Gestion des Annonces</h1>
+        <div class="table-container">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Titre</th>
+                        <th>Utilisateur</th>
+                        <th>Prix</th>
+                        <th>Catégorie</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${ads.map(ad => `
+                        <tr data-id="${ad._id}">
+                            <td>${ad.title}</td>
+                            <td>${ad.userId ? ad.userId.name : 'N/A'}</td>
+                            <td>${ad.price} €</td>
+                            <td>${ad.category}</td>
+                            <td class="table-actions">
+                                <button class="btn-delete">Supprimer</button>
+                            </td>
+                        </tr>
+                    `).join('')}
+                </tbody>
+            </table>
+        </div>
+    `;
+}
+
+window.addEventListener('hashchange', router);
+window.addEventListener('load', router);
+
+document.getElementById('logout-btn').addEventListener('click', () => {
+    localStorage.removeItem('mapmarket_auth_token');
+    window.location.replace('/index.html');
+});
+
+const modal = document.getElementById('confirmation-modal');
+const confirmBtn = document.getElementById('confirm-action-btn');
+const cancelBtn = document.getElementById('cancel-action-btn');
+let actionToConfirm = null;
+
+function showConfirmationModal(text, onConfirm) {
+    document.getElementById('modal-text').textContent = text;
+    modal.classList.replace('modal-hidden', 'modal-visible');
+    actionToConfirm = onConfirm;
+}
+
+confirmBtn.addEventListener('click', () => {
+    if (actionToConfirm) actionToConfirm();
+    modal.classList.replace('modal-visible', 'modal-hidden');
+});
+
+cancelBtn.addEventListener('click', () => {
+    modal.classList.replace('modal-visible', 'modal-hidden');
+});
+
+mainContent.addEventListener('click', async (e) => {
+    if (e.target.classList.contains('btn-delete')) {
+        const row = e.target.closest('tr');
+        const id = row.dataset.id;
+        const route = window.location.hash;
+
+        if (route === '#users') {
+            showConfirmationModal('Supprimer cet utilisateur ?', async () => {
+                await secureFetch(`/api/admin/users/${id}`, { method: 'DELETE' });
+                renderUsers();
+            });
+        } else if (route === '#ads') {
+            showConfirmationModal('Supprimer cette annonce ?', async () => {
+                await secureFetch(`/api/admin/ads/${id}`, { method: 'DELETE' });
+                renderAds();
+            });
+        }
+    }
+});

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const adminController = require('../controllers/adminController');
+const { protect, isAdmin } = require('../middlewares/authMiddleware');
+
+const router = express.Router();
+
+// Toutes les routes nécessitent une authentification et un rôle administrateur
+router.use(protect);
+router.use(isAdmin);
+
+router.get('/stats', adminController.getDashboardStats);
+
+router.route('/users')
+    .get(adminController.getAllUsers);
+
+router.route('/users/:id')
+    .patch(adminController.updateUser)
+    .delete(adminController.deleteUser);
+
+router.route('/ads')
+    .get(adminController.getAllAds);
+
+router.route('/ads/:id')
+    .patch(adminController.updateAd)
+    .delete(adminController.deleteAd);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const alertRoutes = require('./routes/alertRoutes');
 const favoriteRoutes = require('./routes/favoriteRoutes');
 const notificationRoutes = require('./routes/notificationRoutes');
 const settingRoutes = require('./routes/settingRoutes');
+const adminRoutes = require('./routes/adminRoutes');
 const messageCtrl = require('./controllers/messageController');
 
 const app = express();
@@ -175,6 +176,7 @@ app.use('/api/alerts', alertRoutes);
 app.use('/api/favorites', favoriteRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api/settings', settingRoutes);
+app.use('/api/admin', adminRoutes);
 
 // Favicon (évite une erreur inutile dans les logs)
 app.get('/favicon.ico', (req, res) => {


### PR DESCRIPTION
## Summary
- add isAdmin check in auth middleware
- create admin API routes and controller
- register admin router in server
- add admin dashboard HTML, CSS, and JS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68614a8cc8e483249abbdd8457c1d285