### PR TITLE
Add bulk ad creation interface

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -19,6 +19,7 @@
                 <li><a href="#dashboard" class="nav-link active"><i class="fa-solid fa-chart-line"></i> Dashboard</a></li>
                 <li><a href="#users" class="nav-link"><i class="fa-solid fa-users"></i> Utilisateurs</a></li>
                 <li><a href="#ads" class="nav-link"><i class="fa-solid fa-bullhorn"></i> Annonces</a></li>
+                <li><a href="#bulk-ads" class="nav-link">Ajout en Masse</a></li>
                 <li><a href="#categories" class="nav-link"><i class="fa-solid fa-list"></i> Catégories</a></li>
                 <li><a href="#settings" class="nav-link"><i class="fa-solid fa-cog"></i> Paramètres</a></li>
             </ul>

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -392,3 +392,54 @@ body {
 }
 .badge.admin { background-color: var(--accent-color); }
 .badge.user { background-color: var(--medium-gray); }
+
+/* Styles pour l'ajout en masse d'annonces */
+#bulk-ads-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 4rem;
+}
+
+.ad-form-row {
+    display: grid;
+    grid-template-columns: 1fr 2fr 120px 1fr auto;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.ad-form-row input,
+.ad-form-row textarea {
+    padding: 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-family: inherit;
+}
+
+.ad-form-row textarea {
+    resize: vertical;
+    min-height: 60px;
+}
+
+.btn-remove-row {
+    background: none;
+    border: none;
+    color: var(--danger-color);
+    cursor: pointer;
+    font-size: 1.2rem;
+}
+
+.bulk-actions-footer {
+    position: sticky;
+    bottom: 0;
+    background: var(--white);
+    padding: 1rem 0;
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-end;
+    border-top: 1px solid var(--border-color);
+}
+
+.input-error {
+    border-color: var(--danger-color);
+}


### PR DESCRIPTION
## Summary
- allow admins to bulk create ads
- wire new `#bulk-ads` route in admin panel
- implement dynamic row management and submission logic
- style bulk ad creation page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68616c7456348324a05d91e50196531e