### PR TITLE
Fix typing event socket reference

### DIFF
--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -891,18 +891,24 @@ function handleNewMessageReceived({ message, thread, unreadThreadCount }) {
 }
 
 function sendTypingEvent() {
-    if (socket?.connected && activeThreadId) {
-        if (!typingTimer) socket.emit('typing', { threadId: activeThreadId, isTyping: true });
+    if (window.socket?.connected && activeThreadId) {
+        if (!typingTimer) window.socket.emit('typing', {
+            threadId: activeThreadId,
+            isTyping: true
+        });
         clearTimeout(typingTimer);
         typingTimer = setTimeout(stopTypingEvent, TYPING_TIMEOUT);
     }
 }
 
 function stopTypingEvent() {
-    if (socket?.connected && activeThreadId) {
+    if (window.socket?.connected && activeThreadId) {
         clearTimeout(typingTimer);
         typingTimer = null;
-        socket.emit('typing', { threadId: activeThreadId, isTyping: false });
+        window.socket.emit('typing', {
+            threadId: activeThreadId,
+            isTyping: false
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- use `window.socket` consistently in messages module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68652f8b112083249cd1d28e59a6d052