### PR TITLE
Fix thread participant check in sendMessage handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -244,7 +244,8 @@ io.on('connection', (socket) => {
 
         try {
             const thread = await Thread.findById(threadId);
-            if (!thread || !thread.participants.includes(socket.user._id)) {
+            const isParticipant = thread && thread.participants.some(p => p.user.toString() === socket.user._id.toString());
+            if (!thread || !isParticipant) {
                 return socket.emit('messageError', { message: 'Accès non autorisé à cette conversation.' });
             }
 


### PR DESCRIPTION
## Summary
- correct sendMessage event to properly verify the participant list before allowing message sending

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68653ab1f5688324ac0c24d0391d9c80