### PR TITLE
Fix message endpoint in front-end

### DIFF
--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -734,7 +734,7 @@ async function sendMessage() {
     }
 
     try {
-        const res = await secureFetch(`${API_MESSAGES_URL}`, {
+        const res = await secureFetch(`${API_MESSAGES_URL}/messages`, {
             method: 'POST',
             body: { threadId: activeThreadId, content: text }
         }, false);


### PR DESCRIPTION
## Summary
- fix sendMessage to call the correct `/api/messages/messages` endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6865461538848324be59420b694ef6b6