### PR TITLE
Fix message creation mismatch

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -258,11 +258,13 @@ exports.getMessagesForThread = asyncHandler(async (req, res, next) => {
  * POST /api/messages
  */
 exports.createMessage = asyncHandler(async (req, res, next) => {
-    const { threadId, content } = req.body;
+    const { threadId, text, content } = req.body;
     const senderId = req.user.id;
 
-    if (!threadId || !content) {
-        return next(new AppError('threadId et content sont requis.', 400));
+    const messageText = text || content;
+
+    if (!threadId || !messageText) {
+        return next(new AppError('threadId et contenu du message sont requis.', 400));
     }
 
     const thread = await Thread.findById(threadId).populate('participants.user', 'name avatarUrl isOnline lastSeen');
@@ -273,7 +275,7 @@ exports.createMessage = asyncHandler(async (req, res, next) => {
     let newMessage = await Message.create({
         threadId,
         senderId,
-        text: content,
+        text: messageText,
         status: 'sent'
     });
 

--- a/middlewares/validationMiddleware.js
+++ b/middlewares/validationMiddleware.js
@@ -165,10 +165,11 @@ const updateAdSchema = Joi.object({
 const createMessageSchema = Joi.object({
     threadId: Joi.string().hex().length(24).required(),
     text: Joi.string().trim().allow('').max(2000).optional(),
+    content: Joi.string().trim().allow('').max(2000).optional(),
     type: Joi.string().optional(),
     metadata: Joi.any().optional(),
     tempId: Joi.string().optional()
-});
+}).or('text', 'content');
 
 // Schéma pour l'envoi de message avec image (où le texte est optionnel)
 const sendMessageWithImageSchema = Joi.object({

--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -736,7 +736,7 @@ async function sendMessage() {
     try {
         const res = await secureFetch(`${API_MESSAGES_URL}/messages`, {
             method: 'POST',
-            body: { threadId: activeThreadId, content: text }
+            body: { threadId: activeThreadId, text }
         }, false);
 
         if (res?.data?.message) {

--- a/server.js
+++ b/server.js
@@ -236,9 +236,11 @@ io.on('connection', (socket) => {
     });
 
     socket.on('sendMessage', async (data) => {
-        const { threadId, content } = data;
+        const { threadId, text, content } = data;
 
-        if (!threadId || !content || content.trim() === '') {
+        const messageText = text || content;
+
+        if (!threadId || !messageText || messageText.trim() === '') {
             return socket.emit('messageError', { message: 'Contenu du message ou ID de conversation manquant.' });
         }
 
@@ -252,7 +254,7 @@ io.on('connection', (socket) => {
             let newMessage = new Message({
                 threadId,
                 senderId: socket.user._id,
-                text: content.trim()
+                text: messageText.trim()
             });
             await newMessage.save();
 


### PR DESCRIPTION
## Summary
- allow `text` or `content` fields when validating message creation
- accept both fields in controller logic
- adjust socket handling to accept `text`
- send `text` in frontend fetch

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68654892b2608324b3dc7c529160d2b5