### PR TITLE
Fix typing indicator variable initialization

### DIFF
--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -89,7 +89,7 @@ function initializeUI() {
         chatMessagesContainer: 'chat-messages-container',
         chatMessageTemplate: 'chat-message-template',
         chatHistoryLoader: 'chat-history-loader',
-        chatTypingIndicator: 'typing-indicator',
+        typingIndicator: 'typing-indicator',
         chatInputArea: 'chat-input-area',
         chatMessageInput: 'chat-message-input',
         sendChatMessageBtn: 'send-chat-message-btn',


### PR DESCRIPTION
## Summary
- fix DOM element initialization for typing indicator

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68667597a0748324becf8e85c567640b