### PR TITLE
Extract More Options modal CSS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="/styles.css">
     <link rel="stylesheet" href="/profile-modal.css">
     <link rel="stylesheet" href="/messages-modal.css">
+    <link rel="stylesheet" href="/more-options-modal.css">
     <link rel="stylesheet" href="/header.css">
     <link rel="manifest" href="/manifest.json">
 </head>

--- a/public/more-options-modal.css
+++ b/public/more-options-modal.css
@@ -1,0 +1,44 @@
+/* More Options Modal Styles */
+
+/* Modal Container */
+#more-options-modal .modal-content {
+    max-width: 350px;
+}
+
+/* Options List */
+.more-options-list {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Option Buttons */
+.more-option-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    font-size: 1rem;
+    color: var(--text-color-base);
+    border: none;
+    background: none;
+    width: 100%;
+    text-align: left;
+    border-radius: var(--border-radius-sm);
+}
+
+.more-option-item:hover {
+    background-color: var(--gray-100);
+    color: var(--primary-color);
+}
+
+.more-option-item i {
+    width: 24px;
+    text-align: center;
+    color: var(--gray-500);
+    font-size: 1.1em;
+    transition: color var(--transition-duration-short) var(--transition-timing-function);
+}
+
+.more-option-item:hover i {
+    color: var(--primary-color);
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1482,47 +1482,6 @@ h4 {
     font-weight: 500;
 }
 
-/* More Options Modal */
-#more-options-modal .modal-content {
-    max-width: 350px;
-}
-
-.more-options-list {
-    display: flex;
-    flex-direction: column;
-}
-
-.more-option-item {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md);
-    padding: var(--spacing-md);
-    font-size: 1rem;
-    color: var(--text-color-base);
-    border: none;
-    background: none;
-    width: 100%;
-    text-align: left;
-    border-radius: var(--border-radius-sm);
-}
-
-.more-option-item:hover {
-    background-color: var(--gray-100);
-    color: var(--primary-color);
-}
-
-.more-option-item i {
-    width: 24px;
-    text-align: center;
-    color: var(--gray-500);
-    font-size: 1.1em;
-    transition: color var(--transition-duration-short) var(--transition-timing-function);
-}
-
-.more-option-item:hover i {
-    color: var(--primary-color);
-}
-
 /* FORMS (General) */
 .form-group {
     margin-bottom: var(--spacing-md);


### PR DESCRIPTION
## Summary
- create `more-options-modal.css` for the "Plus d'options" modal
- link new stylesheet in `index.html`
- remove the modal-specific rules from `styles.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68678a5149e88324aa35d627c54ea2cb