### PR TITLE
Move form styles into separate stylesheet

### DIFF
--- a/public/forms.css
+++ b/public/forms.css
@@ -1,0 +1,90 @@
+/* FORMS (General) */
+.form-group {
+    margin-bottom: var(--spacing-md);
+}
+
+.form-group label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: var(--spacing-xs);
+    color: var(--gray-700);
+    font-size: 0.9rem;
+}
+
+.form-control {
+    display: block;
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-md);
+    font-size: 1rem;
+    line-height: 1.5;
+    color: var(--text-color-base);
+    background-color: var(--component-bg);
+    background-clip: padding-box;
+    border: 1px solid var(--input-border-color);
+    border-radius: var(--border-radius-md);
+    transition: border-color var(--transition-duration-short) var(--transition-timing-function),
+        box-shadow var(--transition-duration-short) var(--transition-timing-function);
+}
+
+.form-control:focus {
+    border-color: var(--input-focus-border-color);
+    outline: 0;
+    box-shadow: 0 0 0 3px rgba(var(--primary-color-rgb), 0.1);
+}
+
+.form-control[readonly] {
+    background-color: var(--gray-100);
+    opacity: 0.8;
+    cursor: not-allowed;
+}
+
+.form-control::placeholder {
+    color: var(--gray-400);
+    opacity: 1;
+}
+
+textarea.form-control {
+    min-height: 80px;
+    resize: vertical;
+}
+
+select.form-control {
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.75rem center;
+    background-size: 16px 12px;
+    padding-right: 2.5rem;
+}
+
+.form-error-message {
+    display: block;
+    margin-top: var(--spacing-xs);
+    font-size: 0.875em;
+    color: var(--danger-color);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+    margin-right: var(--spacing-xs);
+    vertical-align: middle;
+    height: 1em;
+    width: 1em;
+    accent-color: var(--primary-color);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+    border: 1px solid var(--input-border-color);
+    border-radius: var(--border-radius-xs);
+}
+
+input[type="checkbox"]:checked,
+input[type="radio"]:checked {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+}
+
+body.dark-mode select.form-control {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23cccccc' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+}

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,7 @@
 
 
     <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/forms.css">
     <link rel="stylesheet" href="/map.css">
     <link rel="stylesheet" href="/auth-modal.css">
     <link rel="stylesheet" href="/ad-detail-modal.css">

--- a/public/styles.css
+++ b/public/styles.css
@@ -907,93 +907,6 @@ h4 {
     font-weight: 500;
 }
 
-/* FORMS (General) */
-.form-group {
-    margin-bottom: var(--spacing-md);
-}
-
-.form-group label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: var(--spacing-xs);
-    color: var(--gray-700);
-    font-size: 0.9rem;
-}
-
-.form-control {
-    display: block;
-    width: 100%;
-    padding: var(--spacing-sm) var(--spacing-md);
-    font-size: 1rem;
-    line-height: 1.5;
-    color: var(--text-color-base);
-    background-color: var(--component-bg);
-    background-clip: padding-box;
-    border: 1px solid var(--input-border-color);
-    border-radius: var(--border-radius-md);
-    transition: border-color var(--transition-duration-short) var(--transition-timing-function),
-        box-shadow var(--transition-duration-short) var(--transition-timing-function);
-}
-
-.form-control:focus {
-    border-color: var(--input-focus-border-color);
-    outline: 0;
-    box-shadow: 0 0 0 3px rgba(var(--primary-color-rgb), 0.1);
-}
-
-.form-control[readonly] {
-    background-color: var(--gray-100);
-    opacity: 0.8;
-    cursor: not-allowed;
-}
-
-.form-control::placeholder {
-    color: var(--gray-400);
-    opacity: 1;
-}
-
-textarea.form-control {
-    min-height: 80px;
-    resize: vertical;
-}
-
-select.form-control {
-    appearance: none;
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
-    background-repeat: no-repeat;
-    background-position: right 0.75rem center;
-    background-size: 16px 12px;
-    padding-right: 2.5rem;
-}
-
-.form-error-message {
-    display: block;
-    margin-top: var(--spacing-xs);
-    font-size: 0.875em;
-    color: var(--danger-color);
-}
-
-input[type="checkbox"],
-input[type="radio"] {
-    margin-right: var(--spacing-xs);
-    vertical-align: middle;
-    height: 1em;
-    width: 1em;
-    accent-color: var(--primary-color);
-}
-
-input[type="checkbox"],
-input[type="radio"] {
-    border: 1px solid var(--input-border-color);
-    border-radius: var(--border-radius-xs);
-}
-
-input[type="checkbox"]:checked,
-input[type="radio"]:checked {
-    background-color: var(--primary-color);
-    border-color: var(--primary-color);
-}
-
 /* TOAST NOTIFICATIONS */
 #toast-notifications-container {
     position: fixed;
@@ -1316,9 +1229,6 @@ body.dark-mode .toast-close-btn {
     color: inherit;
 }
 
-body.dark-mode select.form-control {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23cccccc' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
-}
 /* Animation du badge */
 .badge-bounce {
     animation: bounce 0.3s ease;


### PR DESCRIPTION
## Summary
- extract generic form styles from `styles.css`
- add new `forms.css` with form-related selectors
- include new stylesheet in `index.html`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6867e23c134c8324bb9444fe3ec608d9