### PR TITLE
Fix ad preview card display

### DIFF
--- a/public/js/map.js
+++ b/public/js/map.js
@@ -556,7 +556,7 @@ export function displayAdsOnMap(ads) {
         if (lat != null && lng != null && adId) {
             const marker = L.marker([lat, lng], { icon: adIconConfig(ad), alt: sanitizeHTML(ad.title) });
             marker.on('click', () => {
-                showAdPreviewCard(ad);
+                handleMarkerClick(ad);
             });
             adMarkersLayer.addLayer(marker);
             adMarkersById[adId] = marker; // Stocker le marqueur par ID
@@ -569,7 +569,13 @@ export function displayAdsOnMap(ads) {
     }
 }
 
+function handleMarkerClick(ad) {
+    console.log('handleMarkerClick -> ad', ad);
+    showAdPreviewCard(ad);
+}
+
 function showAdPreviewCard(ad) {
+    console.log('showAdPreviewCard -> ad', ad);
     const card = document.getElementById('ad-preview-card');
     const image = document.getElementById('preview-card-image');
     const title = document.getElementById('preview-card-title');
@@ -642,6 +648,7 @@ function showAdPreviewCard(ad) {
         document.dispatchEvent(new CustomEvent('mapMarket:viewAdDetails', { detail: { adId: ad._id || ad.id } }));
     };
 
+    console.log('showAdPreviewCard -> displaying preview card');
     card.classList.remove('hidden');
 }
 

--- a/public/map.css
+++ b/public/map.css
@@ -335,3 +335,42 @@ body.dark-mode .map-info-bar {
     background-color: rgba(var(--category-electronique-color), 0.1);
     color: var(--category-electronique-color);
 }
+
+/* Responsive Ad Preview Card */
+#ad-preview-card {
+    position: absolute;
+    left: var(--spacing-md);
+    right: var(--spacing-md);
+    bottom: calc(var(--bottom-nav-height) + var(--spacing-md));
+    background-color: var(--component-bg);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-lg);
+    display: flex;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    transform: translateY(100%);
+    transition: transform 0.3s ease-in-out;
+    z-index: 1000;
+    align-items: center;
+}
+
+#ad-preview-card:not(.hidden) {
+    transform: translateY(0);
+}
+
+@media (min-width: 768px) {
+    #ad-preview-card {
+        width: 340px;
+        left: var(--spacing-md);
+        right: auto;
+        border-radius: var(--border-radius-md);
+    }
+}
+
+@media (max-width: 767px) {
+    #ad-preview-card {
+        left: var(--spacing-xs);
+        right: var(--spacing-xs);
+        border-radius: var(--border-radius-lg) var(--border-radius-lg) 0 0;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure marker clicks always show preview card
- log preview card updates for debugging
- style preview card as responsive bottom sheet

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686d0e4603f08324a670c6afa449ae6a