### PR TITLE
Fix desktop layout for ad preview cards

### DIFF
--- a/public/item-list.css
+++ b/public/item-list.css
@@ -83,3 +83,48 @@
     display: block;
     color: var(--gray-400);
 }
+
+@media (min-width: 768px) {
+    .ad-preview-card {
+        display: flex;
+        height: 140px;
+        position: relative;
+        overflow: hidden;
+        transition: box-shadow 0.3s ease, transform 0.3s ease;
+    }
+
+    .ad-preview-card:hover {
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
+        transform: translateY(-4px);
+    }
+
+    .ad-preview-card .preview-card-image {
+        flex: 0 0 140px;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .ad-preview-card .preview-card-details {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        padding: 12px 16px;
+    }
+
+    .ad-preview-card .preview-card-meta {
+        margin-top: auto;
+    }
+
+    .ad-preview-card .favorite-btn {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 2;
+        background-color: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(4px);
+        border-radius: 50%;
+        width: 36px;
+        height: 36px;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    }
+}


### PR DESCRIPTION
## Summary
- enhance `ad-preview-card` styles for desktop layouts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686d152201e88324872d727387df2f90