### PR TITLE
Truncate message previews in thread list

### DIFF
--- a/public/js/messages.js
+++ b/public/js/messages.js
@@ -492,8 +492,11 @@ function renderThreadList(threadsData) {
             ? sanitizeHTML(thread.lastMessage.text)
             : (thread.lastMessage?.imageUrl ? '[Image]' : 'Début de la conversation');
 
+        const truncatedPreview =
+            previewText.length > 60 ? previewText.slice(0, 60) + '...' : previewText;
+
         if (userNameEl) userNameEl.textContent = `${sanitizeHTML(lastMessageSender)}: `;
-        if (messagePreviewEl) messagePreviewEl.textContent = previewText;
+        if (messagePreviewEl) messagePreviewEl.textContent = truncatedPreview;
 
         // La logique pour l'heure et le badge non lu reste la même
         if (timeEl) timeEl.textContent = thread.lastMessage ? formatDate(thread.lastMessage.createdAt, { hour: '2-digit', minute: '2-digit' }) : '';

--- a/public/messages-modal.css
+++ b/public/messages-modal.css
@@ -74,6 +74,12 @@
     text-overflow: ellipsis;
 }
 
+.thread-item__message-line {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .thread-meta {
     margin-left: auto;
     text-align: right;


### PR DESCRIPTION
## Summary
- shorten preview text in the thread list to 60 characters
- ensure single-line overflow handling in message list items

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_687e3fb3b4148324b76f4ee2d19623e4